### PR TITLE
Modify generate-spec script to include openapi version

### DIFF
--- a/cmd/spec/main.go
+++ b/cmd/spec/main.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"fmt"
 
+	"github.com/ghodss/yaml"
 	"github.com/RedHatInsights/quickstarts/pkg/models"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/getkin/kin-openapi/openapi3gen"
@@ -35,14 +37,28 @@ func main() {
 	err = json.NewEncoder(b).Encode(swagger)
 	checkErr(err)
 
+	schema, err := yaml.JSONToYAML(b.Bytes())
+	checkErr(err)
+
+	paths, err := ioutil.ReadFile("./cmd/spec/path.yaml")
+	checkErr(err)
+
+	b = &bytes.Buffer{}
+	b.Write(schema)
+	b.Write(paths)
+
 	doc, err := openapi3.NewLoader().LoadFromData(b.Bytes())
 	checkErr(err)
 
-	jsonB, err := doc.MarshalJSON()
+	jsonB, err := json.MarshalIndent(doc, "", "  ")
 	checkErr(err)
 
 	err = ioutil.WriteFile("./spec/openapi.json", jsonB, 0666)
 	checkErr(err)
+	err = ioutil.WriteFile("./spec/openapi.yaml", b.Bytes(), 0666)
+	checkErr(err)
+
+	fmt.Println("Spec was generated successfully")
 }
 
 func checkErr(err error) {

--- a/cmd/spec/path.yaml
+++ b/cmd/spec/path.yaml
@@ -1,0 +1,6 @@
+info:
+  license:
+    name: MIT
+  title: quickstarts
+  version: 1.0.0
+openapi: 3.0.0

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -1,1 +1,89 @@
-{"components":{"schemas":{"v1.Quickstart":{"properties":{"Content":{"format":"byte","type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{"minimum":0,"type":"integer"},"Title":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"v1.QuickstartProgress":{"properties":{"AccountId":{"type":"integer"},"Progress":{"format":"byte","type":"string"},"Quickstart":{"properties":{"Content":{"format":"byte","type":"string"},"CreatedAt":{"format":"date-time","type":"string"},"DeletedAt":{},"ID":{"minimum":0,"type":"integer"},"Title":{"type":"string"},"UpdatedAt":{"format":"date-time","type":"string"}},"type":"object"},"QuickstartID":{"minimum":0,"type":"integer"}},"type":"object"}}},"info":null,"openapi":"","paths":null}
+{
+  "components": {
+    "schemas": {
+      "v1.Quickstart": {
+        "properties": {
+          "bundles": {
+            "format": "byte",
+            "type": "string"
+          },
+          "content": {
+            "format": "byte",
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "deletedAt": {},
+          "id": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "v1.QuickstartProgress": {
+        "properties": {
+          "accountId": {
+            "type": "integer"
+          },
+          "progress": {
+            "format": "byte",
+            "type": "string"
+          },
+          "quickstart": {
+            "properties": {
+              "bundles": {
+                "format": "byte",
+                "type": "string"
+              },
+              "content": {
+                "format": "byte",
+                "type": "string"
+              },
+              "createdAt": {
+                "format": "date-time",
+                "type": "string"
+              },
+              "deletedAt": {},
+              "id": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "title": {
+                "type": "string"
+              },
+              "updatedAt": {
+                "format": "date-time",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
+          "quickstartID": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "license": {
+      "name": "MIT"
+    },
+    "title": "quickstarts",
+    "version": "1.0.0"
+  },
+  "openapi": "3.0.0",
+  "paths": null
+}

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,61 @@
+components:
+  schemas:
+    v1.Quickstart:
+      properties:
+        bundles:
+          format: byte
+          type: string
+        content:
+          format: byte
+          type: string
+        createdAt:
+          format: date-time
+          type: string
+        deletedAt: {}
+        id:
+          minimum: 0
+          type: integer
+        title:
+          type: string
+        updatedAt:
+          format: date-time
+          type: string
+      type: object
+    v1.QuickstartProgress:
+      properties:
+        accountId:
+          type: integer
+        progress:
+          format: byte
+          type: string
+        quickstart:
+          properties:
+            bundles:
+              format: byte
+              type: string
+            content:
+              format: byte
+              type: string
+            createdAt:
+              format: date-time
+              type: string
+            deletedAt: {}
+            id:
+              minimum: 0
+              type: integer
+            title:
+              type: string
+            updatedAt:
+              format: date-time
+              type: string
+          type: object
+        quickstartID:
+          minimum: 0
+          type: integer
+      type: object
+info:
+  license:
+    name: MIT
+  title: quickstarts
+  version: 1.0.0
+openapi: 3.0.0


### PR DESCRIPTION
In order to generate the python API client from the openapi file, the spec needs a version. 

I am following https://github.com/RedHatInsights/edge-api/blob/703808dee91e0ec5f67668ffb14a4ee6dd94ab86/cmd/spec/main.go with this PR.

This PR is:
- adding a path.yaml file to include the openapi version as well as some other info (paths can be added to this file later)
- adding some stuff to properly indent the resultant spec to make it more readable
- add openapi.yaml in addition to openapi.json

cc @Hyperkid123 @rvsia 
