### PR TITLE
Drafted Create app panel

### DIFF
--- a/docs/help-topics/appstudio-incontext-help/appstudio-in-context.yml
+++ b/docs/help-topics/appstudio-incontext-help/appstudio-in-context.yml
@@ -12,7 +12,8 @@
        App Studio can build apps written in the following languages: Python, Java, Go, and Node.js.
        To get started, add a URL of your GitHub repo. Then, we’ll fetch your code, build a container image for you, and deploy it.
     1. **Quay container image**
-       App Studio can use an existing image you already have stored in the Quay container registry. The advantage of an image is that you can code in any language and use any container image type, App Studio will deploy it for you to the Development environment.
+       App Studio can use an existing image you already have stored in the Quay container registry. The advantage of an image is that you can code in any language and use any container image type,
+       App Studio will deploy it for you to the Development environment.
     1. **Sample code**
        Try one of our samples to explore App Studio. Samples are great ways to test out different languages in App Studio.
     Once you add your code, you can edit deployment settings, for example, a target port or environment variables. You can always change them later.
@@ -22,9 +23,16 @@
 
 - name: app-view
   tags:
-  title: Manage your application
+  title: Manage your apps
   content: |-
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    As you build and scale your app, this view shows everything you need to know about your app and components in one place.
+    - **Components**
+      You’ll discover a list of your components, their build statuses, and logs in a single view. We keep an eye on components built from your GitHub code and rebuild them whenever you change the source code.
+      From the **Actions menu**, you can tweak the settings, such as port value, at any time for each component.
+      Changing global settings of any component overrides global settings across all the environments.
+      Changing build settings only affects one component.
+    - **Environments**
+      Your source code is automatically built and deployed to the Development environment that comes with your service preview. You can change the deployment settings for each component as you scale your app across environments from the **Actions menu**.
   # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162
   links: []
 

--- a/docs/help-topics/appstudio-incontext-help/appstudio-in-context.yml
+++ b/docs/help-topics/appstudio-incontext-help/appstudio-in-context.yml
@@ -4,10 +4,20 @@
 
 - name: create-app
   tags:
-  title: Create a new application
+  title: Create your app
   content: |-
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162  
+    Build and deploy your apps in minutes. Tell us where to find your code, and let App Studio do the rest.
+    Here are some possible sources for your code:
+    1. **GitHub repository**
+       App Studio can build apps written in the following languages: Python, Java, Go, and Node.js.
+       To get started, add a URL of your GitHub repo. Then, we’ll fetch your code, build a container image for you, and deploy it.
+    1. **Quay container image**
+       App Studio can use an existing image you already have stored in the Quay container registry. The advantage of an image is that you can code in any language and use any container image type, App Studio will deploy it for you to the Development environment.
+    1. **Sample code**
+       Try one of our samples to explore App Studio. Samples are great ways to test out different languages in App Studio.
+    Once you add your code, you can edit deployment settings, for example, a target port or environment variables. You can always change them later.
+    When everything looks good, click **Create**. Your app will automatically be deployed to the Development environment that is included with this Service Preview.
+  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162
   links: []
 
 - name: app-view
@@ -15,7 +25,7 @@
   title: Manage your application
   content: |-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162  
+  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162
   links: []
 
 - name: create-environment
@@ -23,7 +33,7 @@
   title: Create a new environment
   content: |-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162  
+  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162
   links: []
 
 - name: promote-component
@@ -31,6 +41,6 @@
   title: Promote your components
   content: |-
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162  
+  # This array has currently required due to an internal quickstart bug. It always expect the array to be defined. https://github.com/patternfly/patternfly-quickstarts/pull/162
   links: []
 


### PR DESCRIPTION
@Hyperkid123 Hi Martin, will you please review the text here? I wonder whether an ordered Markdown list would be rendered correctly (as it relies on indentations same as yaml).

Will using multiline strings blocks (scalars) help? I'm not sure Markdown will work inside them...

In the ideal world, we hoped to get a mixed list here, but I'm afraid it'll require too many spaces and won't be rendered in the end. Is there a way of getting something like that in App Studio side panels?

1. **GitHub repository**

   App Studio can build apps written in the following languages:
    - Python
    - Java
    - Go
    - Node.js
    
   To get started, add a URL of your GitHub repo. Then, we’ll fetch your code, build a container image for you, and deploy it.
       
1. **Quay container image**

Thank you in advance for any help or tips.
