### PR TITLE
Add tags to the API endpoints

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -268,6 +268,16 @@
     "version": "1.0.0"
   },
   "openapi": "3.0.0",
+  "tags": [
+    {
+      "description": "A help topic",
+      "name": "helptopic"
+    },
+    {
+      "description": "The content for a quickstart",
+      "name": "quickstart"
+    }
+  ],
   "paths": {
     "/helptopics": {
       "get": {
@@ -302,7 +312,10 @@
             "description": "A JSON array of all help topics"
           }
         },
-        "summary": "Returns list of all help topics"
+        "summary": "Returns list of all help topics",
+        "tags": [
+          "helptopic"
+        ]
       }
     },
     "/helptopics/{name}": {
@@ -349,7 +362,10 @@
             "description": "Not found"
           }
         },
-        "summary": "Return a help topics set by topic name"
+        "summary": "Return a help topics set by topic name",
+        "tags": [
+          "helptopic"
+        ]
       }
     },
     "/quickstarts": {
@@ -388,7 +404,10 @@
             "description": "A JSON array of all quickstarts"
           }
         },
-        "summary": "Returns list of all quickstarts"
+        "summary": "Returns list of all quickstarts",
+        "tags": [
+          "quickstart"
+        ]
       }
     },
     "/quickstarts/{id}": {
@@ -430,7 +449,10 @@
             "description": "Not found"
           }
         },
-        "summary": "Return a quickstarts by ID"
+        "summary": "Return a quickstarts by ID",
+        "tags": [
+          "quickstart"
+        ]
       }
     }
   }

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -183,6 +183,11 @@ info:
   title: quickstarts
   version: 1.0.0
 openapi: 3.0.0
+tags:
+  - description: A help topic
+    name: helptopic
+  - description: The content for a quickstart
+    name: quickstart
 paths:
   /quickstarts:
     get:
@@ -204,6 +209,8 @@ paths:
       - $ref: '#/components/schemas/queryParams/Application'
       - $ref: '#/components/schemas/queryParams/Limit'
       - $ref: '#/components/schemas/queryParams/Offset'      
+      tags:
+        - quickstart
   /quickstarts/{id}:
     get:
       summary: Return a quickstarts by ID
@@ -228,6 +235,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFound'
+      tags:
+        - quickstart
   /helptopics:
     get:
       summary: Returns list of all help topics
@@ -247,6 +256,8 @@ paths:
       - $ref: '#/components/schemas/queryParams/Bundle'
       - $ref: '#/components/schemas/queryParams/Application'
       - $ref: '#/components/schemas/queryParams/Name'
+      tags:
+        - helptopic
   /helptopics/{name}:
     get:
       summary: Return a help topics set by topic name
@@ -274,4 +285,5 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFound'
-
+      tags:
+        - helptopic


### PR DESCRIPTION
Adding tags makes the client generators create separate objects for each tag, e.g.

```python
from quickstarts_client.apis.helptopics_api import HelptopicsApi

helptopics_api = HelptopicsApi()
help_topics = helptopics_api.list_helptopics()
```

Versus a "default_api" object

```python
from quickstarts_client.api.default_api import DefaultApi

default_api = DefaultApi()
help_topics = default_api.helptopics_get()
```