### PR TITLE
Allow .yaml extensions

### DIFF
--- a/cmd/validate/validate_topics.go
+++ b/cmd/validate/validate_topics.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -90,7 +89,6 @@ func validateStructure() {
 		// validate topic file existance
 		m := regexp.MustCompile("metadata.ya?ml$")
 		topicFileName := filePath
-		log.Println("filename" + topicFileName)
 		if _, err := os.Stat(m.ReplaceAllString(topicFileName, metadata.Name+".yml")); err == nil {
 			topicFileName = m.ReplaceAllString(topicFileName, metadata.Name+".yml")
 		} else {

--- a/cmd/validate/validate_topics.go
+++ b/cmd/validate/validate_topics.go
@@ -59,15 +59,8 @@ func notMatch(r string, msg string) validation.RuleFunc {
 }
 
 func validateStructure() {
-	metadataFiles, err := filepath.Glob("./docs/help-topics/**/metadata.yaml")
+	metadataFiles, err := filepath.Glob("./docs/help-topics/**/metadata.y*")
 	handleErr(err)
-	if len(metadataFiles) > 0 {
-		err = fmt.Errorf("yaml extenstions are not supported. Please use yml extenstions for: %v", metadataFiles)
-		handleErr(err)
-	}
-
-	// metadataFiles, err := filepath.Glob("./docs/help-topics/**/metadata.y*")
-	// handleErr(err)
 
 	for _, filePath := range metadataFiles {
 		yamlfile, err := ioutil.ReadFile(filePath)

--- a/cmd/validate/validate_topics.go
+++ b/cmd/validate/validate_topics.go
@@ -66,8 +66,8 @@ func validateStructure() {
 		handleErr(err)
 	}
 
-	metadataFiles, err = filepath.Glob("./docs/help-topics/**/metadata.yml")
-	handleErr(err)
+	// metadataFiles, err := filepath.Glob("./docs/help-topics/**/metadata.y*")
+	// handleErr(err)
 
 	for _, filePath := range metadataFiles {
 		yamlfile, err := ioutil.ReadFile(filePath)

--- a/cmd/validate/validate_topics.go
+++ b/cmd/validate/validate_topics.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -86,9 +88,14 @@ func validateStructure() {
 		}
 
 		// validate topic file existance
-		m := regexp.MustCompile("metadata.yml$")
+		m := regexp.MustCompile("metadata.ya?ml$")
 		topicFileName := filePath
-		topicFileName = m.ReplaceAllString(topicFileName, metadata.Name+".yml")
+		log.Println("filename" + topicFileName)
+		if _, err := os.Stat(m.ReplaceAllString(topicFileName, metadata.Name+".yml")); err == nil {
+			topicFileName = m.ReplaceAllString(topicFileName, metadata.Name+".yml")
+		} else {
+			topicFileName = m.ReplaceAllString(topicFileName, metadata.Name+".yaml")
+		}
 		yamlfile, err = ioutil.ReadFile(topicFileName)
 		handleFileErr(topicFileName, err)
 		jsonContent, err = yaml.YAMLToJSON(yamlfile)

--- a/pkg/database/db_seed.go
+++ b/pkg/database/db_seed.go
@@ -157,7 +157,6 @@ func seedHelpTopic(t MetadataTemplate, defaultTag models.Tag) ([]models.HelpTopi
 	jsonContent, err := yaml.YAMLToJSON(yamlfile)
 	var d []map[string]interface{}
 	if err := json.Unmarshal(jsonContent, &d); err != nil {
-		log.Println("this is where the error is")
 		return returnValue, err
 	}
 

--- a/pkg/database/db_seed.go
+++ b/pkg/database/db_seed.go
@@ -37,16 +37,11 @@ func readMetadata(loc string) (MetadataTemplate, error) {
 		return template, err
 	}
 	m := regexp.MustCompile("metadata.yml$")
-	log.Println(template)
-	log.Println(m)
-	log.Println(loc)
 	if filepath.Ext(loc) == ".yml" {
 		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
 	} else {
 		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yaml")
 	}
-	// template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
-	log.Println(template.ContentPath)
 	return template, nil
 }
 

--- a/pkg/database/db_seed.go
+++ b/pkg/database/db_seed.go
@@ -149,7 +149,6 @@ func seedDefaultTags() map[string]models.Tag {
 
 func seedHelpTopic(t MetadataTemplate, defaultTag models.Tag) ([]models.HelpTopic, error) {
 	yamlfile, err := ioutil.ReadFile(t.ContentPath)
-	log.Println("content path: " + t.ContentPath)
 	returnValue := make([]models.HelpTopic, 0)
 	if err != nil {
 		return returnValue, err

--- a/pkg/database/db_seed.go
+++ b/pkg/database/db_seed.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"regexp"
 
@@ -36,12 +37,13 @@ func readMetadata(loc string) (MetadataTemplate, error) {
 	if err != nil {
 		return template, err
 	}
-	m := regexp.MustCompile("metadata.yml$")
-	if filepath.Ext(loc) == ".yml" {
+	m := regexp.MustCompile("metadata.ya?ml$")
+	if _, err := os.Stat(m.ReplaceAllString(loc, template.Name+".yml")); err == nil {
 		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
 	} else {
 		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yaml")
 	}
+
 	return template, nil
 }
 
@@ -147,7 +149,7 @@ func seedDefaultTags() map[string]models.Tag {
 
 func seedHelpTopic(t MetadataTemplate, defaultTag models.Tag) ([]models.HelpTopic, error) {
 	yamlfile, err := ioutil.ReadFile(t.ContentPath)
-	log.Println(t.ContentPath)
+	log.Println("content path: " + t.ContentPath)
 	returnValue := make([]models.HelpTopic, 0)
 	if err != nil {
 		return returnValue, err

--- a/pkg/database/db_seed.go
+++ b/pkg/database/db_seed.go
@@ -37,19 +37,27 @@ func readMetadata(loc string) (MetadataTemplate, error) {
 		return template, err
 	}
 	m := regexp.MustCompile("metadata.yml$")
-	template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
+	log.Println(template)
+	log.Println(m)
+	log.Println(loc)
+	if filepath.Ext(loc) == ".yml" {
+		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
+	} else {
+		template.ContentPath = m.ReplaceAllString(loc, template.Name+".yaml")
+	}
+	// template.ContentPath = m.ReplaceAllString(loc, template.Name+".yml")
+	log.Println(template.ContentPath)
 	return template, nil
 }
 
 func findTags() []MetadataTemplate {
 	var MetadataTemplates []MetadataTemplate
-	quickstartsFiles, err := filepath.Glob("./docs/quickstarts/**/metadata.yml")
+	quickstartsFiles, err := filepath.Glob("./docs/quickstarts/**/metadata.y*")
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	helpTopicsFiles, err := filepath.Glob("./docs/help-topics/**/metadata.yml")
-
+	helpTopicsFiles, err := filepath.Glob("./docs/help-topics/**/metadata.y*")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -63,7 +71,6 @@ func findTags() []MetadataTemplate {
 		} else {
 			MetadataTemplates = append(MetadataTemplates, tagMetadata)
 		}
-
 	}
 
 	return MetadataTemplates
@@ -145,6 +152,7 @@ func seedDefaultTags() map[string]models.Tag {
 
 func seedHelpTopic(t MetadataTemplate, defaultTag models.Tag) ([]models.HelpTopic, error) {
 	yamlfile, err := ioutil.ReadFile(t.ContentPath)
+	log.Println(t.ContentPath)
 	returnValue := make([]models.HelpTopic, 0)
 	if err != nil {
 		return returnValue, err
@@ -153,6 +161,7 @@ func seedHelpTopic(t MetadataTemplate, defaultTag models.Tag) ([]models.HelpTopi
 	jsonContent, err := yaml.YAMLToJSON(yamlfile)
 	var d []map[string]interface{}
 	if err := json.Unmarshal(jsonContent, &d); err != nil {
+		log.Println("this is where the error is")
 		return returnValue, err
 	}
 

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateTags(t *testing.T) {
-	t.Run("create TAG with corrent tag type", func(t *testing.T) {
+	t.Run("create TAG with correct tag type", func(t *testing.T) {
 		var tag models.Tag
 		tag.Type = models.ApplicationTag
 		tag.Value = "foo"


### PR DESCRIPTION
Working on allowing .yaml extensions. Currently json.unmarshal throws an error when a file has .yaml instead of .yml extension 