### PR TITLE
Fix openapi specs

### DIFF
--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -17,81 +17,6 @@
         },
         "type": "object"
       },
-      "queryParams": {
-        "Application": {
-          "description": "If set, content is associated with a specific CRC application",
-          "explode": true,
-          "in": "query",
-          "name": "application",
-          "required": false,
-          "schema": {
-            "type": "string"
-          },
-          "style": "form"
-        },
-        "Bundle": {
-          "description": "If set, content is associated with a specific CRC bundle",
-          "explode": true,
-          "in": "query",
-          "name": "bundle",
-          "required": false,
-          "schema": {
-            "type": "string"
-          },
-          "style": "form"
-        },
-        "Id": {
-          "description": "identifier",
-          "in": "path",
-          "name": "id",
-          "required": true,
-          "schema": {
-            "type": "integer"
-          }
-        },
-        "Limit": {
-          "description": "Pagination limit",
-          "explode": true,
-          "in": "query",
-          "name": "limit",
-          "required": false,
-          "schema": {
-            "type": "integer"
-          },
-          "style": "form"
-        },
-        "Name": {
-          "description": "Search content by name",
-          "explode": true,
-          "in": "query",
-          "name": "name",
-          "required": false,
-          "schema": {
-            "type": "string"
-          },
-          "style": "form"
-        },
-        "Offset": {
-          "description": "Pagination offset",
-          "explode": true,
-          "in": "query",
-          "name": "offset",
-          "required": false,
-          "schema": {
-            "type": "integer"
-          },
-          "style": "form"
-        },
-        "TopicName": {
-          "description": "identifier",
-          "in": "path",
-          "name": "topicname",
-          "required": true,
-          "schema": {
-            "type": "string"
-          }
-        }
-      },
       "v1.HelpTopic": {
         "properties": {
           "content": {
@@ -104,14 +29,7 @@
           },
           "deletedAt": {
             "format": "date-time",
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "string"
-              }
-            ],
+            "nullable": true,
             "type": "string"
           },
           "groupName": {
@@ -133,14 +51,7 @@
                 },
                 "deletedAt": {
                   "format": "date-time",
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ],
+                  "nullable": true,
                   "type": "string"
                 },
                 "id": {
@@ -181,14 +92,7 @@
           },
           "deletedAt": {
             "format": "date-time",
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "string"
-              }
-            ],
+            "nullable": true,
             "type": "string"
           },
           "id": {
@@ -207,14 +111,7 @@
                 },
                 "deletedAt": {
                   "format": "date-time",
-                  "oneOf": [
-                    {
-                      "type": "null"
-                    },
-                    {
-                      "type": "string"
-                    }
-                  ],
+                  "nullable": true,
                   "type": "string"
                 },
                 "id": {
@@ -258,6 +155,81 @@
         },
         "type": "object"
       }
+    },
+    "parameters": {
+      "Application": {
+        "description": "If set, content is associated with a specific CRC application",
+        "explode": true,
+        "in": "query",
+        "name": "application",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "form"
+      },
+      "Bundle": {
+        "description": "If set, content is associated with a specific CRC bundle",
+        "explode": true,
+        "in": "query",
+        "name": "bundle",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "form"
+      },
+      "Id": {
+        "description": "identifier",
+        "in": "path",
+        "name": "id",
+        "required": true,
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "Limit": {
+        "description": "Pagination limit",
+        "explode": true,
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        },
+        "style": "form"
+      },
+      "Name": {
+        "description": "Search content by name",
+        "explode": true,
+        "in": "query",
+        "name": "name",
+        "required": false,
+        "schema": {
+          "type": "string"
+        },
+        "style": "form"
+      },
+      "Offset": {
+        "description": "Pagination offset",
+        "explode": true,
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "schema": {
+          "type": "integer"
+        },
+        "style": "form"
+      },
+      "TopicName": {
+        "description": "identifier",
+        "in": "path",
+        "name": "name",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      }
     }
   },
   "info": {
@@ -283,13 +255,13 @@
       "get": {
         "parameters": [
           {
-            "$ref": "#/components/schemas/queryParams/Bundle"
+            "$ref": "#/components/parameters/Bundle"
           },
           {
-            "$ref": "#/components/schemas/queryParams/Application"
+            "$ref": "#/components/parameters/Application"
           },
           {
-            "$ref": "#/components/schemas/queryParams/Name"
+            "$ref": "#/components/parameters/Name"
           }
         ],
         "responses": {
@@ -322,7 +294,7 @@
       "get": {
         "parameters": [
           {
-            "$ref": "#/components/schemas/queryParams/TopicName"
+            "$ref": "#/components/parameters/TopicName"
           }
         ],
         "responses": {
@@ -372,16 +344,16 @@
       "get": {
         "parameters": [
           {
-            "$ref": "#/components/schemas/queryParams/Bundle"
+            "$ref": "#/components/parameters/Bundle"
           },
           {
-            "$ref": "#/components/schemas/queryParams/Application"
+            "$ref": "#/components/parameters/Application"
           },
           {
-            "$ref": "#/components/schemas/queryParams/Limit"
+            "$ref": "#/components/parameters/Limit"
           },
           {
-            "$ref": "#/components/schemas/queryParams/Offset"
+            "$ref": "#/components/parameters/Offset"
           }
         ],
         "responses": {
@@ -414,7 +386,7 @@
       "get": {
         "parameters": [
           {
-            "$ref": "#/components/schemas/queryParams/Id"
+            "$ref": "#/components/parameters/Id"
           }
         ],
         "responses": {

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -20,9 +20,7 @@ components:
           type: string
         deletedAt:
           format: date-time
-          oneOf:
-          - type: "null"
-          - type: string
+          nullable: true
           type: string
         groupName:
           type: string
@@ -39,9 +37,7 @@ components:
                 type: string
               deletedAt:
                 format: date-time
-                oneOf:
-                - type: "null"
-                - type: string
+                nullable: true
                 type: string
               id:
                 minimum: 0
@@ -69,9 +65,7 @@ components:
           type: string
         deletedAt:
           format: date-time
-          oneOf:
-          - type: "null"
-          - type: string
+          nullable: true
           type: string
         id:
           minimum: 0
@@ -86,9 +80,7 @@ components:
                 type: string
               deletedAt:
                 format: date-time
-                oneOf:
-                - type: "null"
-                - type: string
+                nullable: true
                 type: string
               id:
                 minimum: 0
@@ -116,67 +108,66 @@ components:
         quickstartName:
           type: string
       type: object
-# It is necessary to have the initial indetation!
-    queryParams:
-      Bundle:
-        name: bundle
-        description: If set, content is associated with a specific CRC bundle
-        in: query
-        required: false
-        schema:
-          type: string
-        explode: true
-        style: form
-      Application:
-        name: application
-        description: If set, content is associated with a specific CRC application
-        in: query
-        required: false
-        schema:
-          type: string
-        explode: true
-        style: form
-      Name:
-        name: name
-        description: Search content by name
-        in: query
-        required: false
-        schema:
-          type: string
-        explode: true
-        style: form
-      Limit:
-        name: limit
-        description: Pagination limit
-        in: query
-        required: false
-        schema:
-          type: integer
-        explode: true
-        style: form
-      Offset:
-        name: offset
-        description: Pagination offset
-        in: query
-        required: false
-        schema:
-          type: integer
-        explode: true
-        style: form
-      Id:
-        name: id
-        description: identifier
-        in: path
-        required: true
-        schema:
-          type: integer
-      TopicName:
-        name: topicname
-        description: identifier
-        in: path
-        required: true
-        schema:
-          type: string
+  parameters:
+    Bundle:
+      name: bundle
+      description: If set, content is associated with a specific CRC bundle
+      in: query
+      required: false
+      schema:
+        type: string
+      explode: true
+      style: form
+    Application:
+      name: application
+      description: If set, content is associated with a specific CRC application
+      in: query
+      required: false
+      schema:
+        type: string
+      explode: true
+      style: form
+    Name:
+      name: name
+      description: Search content by name
+      in: query
+      required: false
+      schema:
+        type: string
+      explode: true
+      style: form
+    Limit:
+      name: limit
+      description: Pagination limit
+      in: query
+      required: false
+      schema:
+        type: integer
+      explode: true
+      style: form
+    Offset:
+      name: offset
+      description: Pagination offset
+      in: query
+      required: false
+      schema:
+        type: integer
+      explode: true
+      style: form
+    Id:
+      name: id
+      description: identifier
+      in: path
+      required: true
+      schema:
+        type: integer
+    TopicName:
+      name: name
+      description: identifier
+      in: path
+      required: true
+      schema:
+        type: string
 info:
   license:
     name: MIT
@@ -205,17 +196,17 @@ paths:
                     items:
                       $ref: '#/components/schemas/v1.Quickstart'
       parameters:
-      - $ref: '#/components/schemas/queryParams/Bundle'
-      - $ref: '#/components/schemas/queryParams/Application'
-      - $ref: '#/components/schemas/queryParams/Limit'
-      - $ref: '#/components/schemas/queryParams/Offset'      
+      - $ref: '#/components/parameters/Bundle'
+      - $ref: '#/components/parameters/Application'
+      - $ref: '#/components/parameters/Limit'
+      - $ref: '#/components/parameters/Offset'      
       tags:
         - quickstart
   /quickstarts/{id}:
     get:
       summary: Return a quickstarts by ID
       parameters:
-      - $ref: '#/components/schemas/queryParams/Id'
+      - $ref: '#/components/parameters/Id'
       responses:
         '200':
           description: A JSON object with a single quickstart content
@@ -253,16 +244,16 @@ paths:
                     items:
                       $ref: '#/components/schemas/v1.HelpTopic'
       parameters:
-      - $ref: '#/components/schemas/queryParams/Bundle'
-      - $ref: '#/components/schemas/queryParams/Application'
-      - $ref: '#/components/schemas/queryParams/Name'
+      - $ref: '#/components/parameters/Bundle'
+      - $ref: '#/components/parameters/Application'
+      - $ref: '#/components/parameters/Name'
       tags:
         - helptopic
   /helptopics/{name}:
     get:
       summary: Return a help topics set by topic name
       parameters:
-      - $ref: '#/components/schemas/queryParams/TopicName'
+      - $ref: '#/components/parameters/TopicName'
       responses:
         '200':
           description: A JSON of a help topic set


### PR DESCRIPTION
### Description

Openapi spec has a few minor errors when used in swagger config. Parameters reference can't be in `schema` but rather in `parameters` config. Since we are using swagger 3.0.0 nullable values has to be marked `nullable: true` in order to be nullish. Path refence has to have same name as in param config - the path `/helptopics/{name}` has `name` in the path whereas `TopicName` in ref params had `topicName` I changed it in the referenced object, not sure if we'd rather change the path to be `/helptopics/{topicName}`, let me know what you'd prefer.