### PR TITLE
Added YAML files for quickstart #4: Configuring granular permissions by service

### DIFF
--- a/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
+++ b/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
@@ -1,0 +1,8 @@
+kind: QuickStarts # kind must always be "QuickStarts"
+name: rbac-granular-malware-rhel-access
+tags: # If you want to use more granular filtering add tags to the quickstart
+  - kind: bundle # use bundle tag for a topic to be accessed from a whole bundle eg. console.redhat.com/insights
+    value: iam
+  - kind: application # use application tag for quickstart used by specific application
+    value: my-user-access
+    

--- a/docs/quickstarts/rbac-granular-malware-rhel-access/rbac-granular-malware-rhel-access.yml
+++ b/docs/quickstarts/rbac-granular-malware-rhel-access/rbac-granular-malware-rhel-access.yml
@@ -1,0 +1,200 @@
+# RBAC quickstart #4
+# Additional info: https://docs.openshift.com/container-platform/4.9/web_console/creating-quick-start-tutorials.html
+# Template from https://github.com/patternfly/patternfly-quickstarts/blob/main/packages/dev/src/quickstarts-data/yaml/template.yaml
+# See quick start instructions here https://github.com/RedHatInsights/quickstarts/tree/main/docs/quickstarts
+metadata:
+  name: rbac-granular-malware-rhel-access
+  # you can add additional metadata here
+  # instructional: true
+spec:
+  displayName: Configuring granular permissions by service
+  durationMinutes: 10
+  # Optional type section, will display as a tile on the card
+  type:
+    text: Quick start
+    # 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey'
+    color: grey
+  # - The icon defined as a base64 value. Example flow:
+  # 1. Find an .svg you want to use, like from here: https://www.patternfly.org/v4/guidelines/icons/#all-icons
+  # 2. Upload the file here and encode it (output format - plain text): https://base64.guru/converter/encode/image
+  # 3. compose - `icon: data:image/svg+xml;base64,<base64 string from step 2>`
+  # - If empty string (icon: ''), will use a default rocket icon
+  # - If set to null (icon: ~) will not show an icon
+  icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
+  prerequisites:
+    - You are an Organization Administrator or have **User Access administrator** permissions
+    - Several groups of users needing different permissions
+  description: |-
+    Limiting access to malware and RHEL services by team 
+  introduction: |-
+    This quick start shows you how to configure different sets of permissions for Red Hat Insights services in the Hybrid Cloud Console (the console). 
+    
+    You can use this workflow when you want your teams – for example, your security team and your system administrators team – to have differing access to certain services and your Red Hat Enterprise Linux (RHEL) systems to align with your organization’s security policies. 
+
+    In this example scenario:
+    - Your security team wants to use the [Insights for RHEL malware-detection service](https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_reporting_malware_signatures_on_rhel_systems_with_the_insights_for_rhel_malware_service/index) to detect potential threats in your infrastructure. Per company policy, they are the only team allowed to see this information. 
+    - Your sysadmin team needs to be able to manage services on RHEL systems, but aren't allowed to see any information related to malware.  
+    - Users outside the sysadmin team aren’t allowed to see any information about your RHEL systems, as it could be a potential avenue for an internal attack.
+
+    After completing this configuration, you’ll have 3 groups with different levels of access to console resources and services. 
+    
+    You can use this example workflow to customize permissions to any service from **User Access**. 
+
+  tasks:
+    - title: Removing all roles from the **Default access** group
+      description: |-
+        Edit the **Default access** group and remove all user roles. (If the **Default access** group was previously modified, then it’s called the **Custom default access** group.)
+        
+        Because user access in the console is additive, removing all roles initially allows you to add back only the permissions that you want.
+        
+        1. Click **User Access** > **Groups**.
+        
+        2. Click the **Default access** (or **Custom default access**) group. 
+        
+        3. In the **Roles** tab, select all roles in the list.
+
+        4. Above the **Roles** list, click&nbsp;&nbsp;<i class="fas fa-ellipsis-v"></i> (More options) > **Remove** to remove these permissions from all users in your organization who are not Organization Administrators.
+        [Organization Administrator permissions are configured in the **Default admin access** group, so they will continue to have access based on the permissions in that group.]{{admonition note}}
+
+        5. Click **Remove roles**.
+
+        6. If you are modifying the **Default access** group for the first time, select the checkbox in the warning and click **Continue** to confirm.
+        
+        Users in your organization now have no default permissions, and the group is called **Custom default access**. Users now only have permissions from the **Default admin access** group or any existing custom groups. 
+
+        [You can undo any changes made to the **Default access** group by clicking **Restore to default** on the **Groups** page.]{{admonition note}}
+
+      # optional - the task's Check your work module
+      review:
+        instructions: |-
+          - Go to **Groups** > **Custom default access** and confirm that there are no roles assigned to the group.
+
+        failedTaskHelp: Try completing the steps again.
+      # optional - the task's success and failure messages
+      summary:
+        success: Shows a success message in the task header
+        failed: Shows a failed message in the task header
+    - title: Creating a group that can manage the malware service
+      description: |-
+        Create a new group named *Security Team* with permissions to manage the malware-detection service, then assign specific team members to the group.
+
+        The users in this group will have permissions to use the malware-detection service to detect potential threats.
+        
+        1. Click **Groups** > **Create group**.
+
+        2. Enter a group name (for example, *Security Team*) and description, and click **Next**.
+
+        3. Find and select the **Malware detection administrator** role. Click **Next** to add it to the group.
+        [You can quickly find a role by filtering by role name.]{{admonition note}}
+
+        4. Add the members of your security team to the group by selecting the checkboxes for those users. Click **Next**.
+            [You can quickly find users by filtering by username, email, or status.]{{admonition note}}
+        5. Review the group details and click **Submit** to create the group.
+        
+        Now the users in the *Security Team* group can monitor and assess your RHEL systems for the presence of malware. 
+
+        To learn more, see:
+        - The [Red Hat Insights documentation](https://access.redhat.com/documentation/en-us/red_hat_insights/2023/html/assessing_and_reporting_malware_signatures_on_rhel_systems_with_the_insights_for_rhel_malware_service/index) for more about using the malware-detection service in the console.
+        - The [User Access Configuration Guide for Role-based Access Control (RBAC)](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/user_access_configuration_guide_for_role-based_access_control_rbac) for more about configuring permissions in the console. 
+
+      # optional - the task's Check your work module
+      review:
+        instructions: |-
+          - Go to **User Access** > **Groups** and click *Security Team* to check that the only role assigned to the group is **Malware detection administrator**.
+
+        failedTaskHelp: Try completing the steps again.
+      # optional - the task's success and failure messages
+      summary:
+        success: Shows a success message in the task header
+        failed: Shows a failed message in the task header
+
+    - title: Creating a group that can manage all RHEL services (except malware-detection)
+      description: |-
+        Create a new group for your system administrators team – who require permissions to manage RHEL resources in the console – and assign specific team members to the group. 
+        
+        Unlike the *Security Team* group, who can only use the malware-detection service, users in the *Sysadmins* group will have administrator roles for most services related to managing RHEL hosts in the console.
+
+        [The roles suggested here are a good example of the roles you may want to add, but we recommend that you review the console [RBAC documentation](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/user_access_configuration_guide_for_role-based_access_control_rbac) for full details on each of these roles. You can also review these roles and their permissions from **User Access** > **Roles** in the console.]{{admonition note}}
+        
+        1. Click **Groups** > **Create group**.
+
+        2. Enter a group name (for example, *Sysadmins*) and description, and click **Next**.
+
+        3. Find and select the following roles to allow users in this group to manage RHEL services. Click **Next** to add these roles to the group:
+            - Compliance administrator
+            - Drift analysis administrator
+            - Inventory administrator
+            - Patch administrator
+            - Policies administrator
+            - Repositories administrator
+            - Resource Optimization administrator
+            - RHEL Advisor administrator
+            - Tasks administrator
+            - Vulnerability administrator
+            - Remediations user
+            - RHC viewer
+            - Subscriptions user
+
+        4. Add your system administrators to the group. Select the checkboxes for those users and click **Next**.
+          [Organization Administrators inherit most administrative roles by default, so you don’t need to add Organization Administrators to the group.]{{admonition note}}
+
+        5. Review the group details and click **Submit** to create the group.
+        
+        You now have a new group called *Sysadmins* that can manage RHEL services in the console.
+
+        To learn more about using these services, see the [Red Hat Insights documentation](https://access.redhat.com/documentation/en-us/red_hat_insights/2023).
+
+      # optional - the task's Check your work module
+      review:
+        instructions: |-
+          - Log in to the console as a member of the *Security Team* group, and confirm that you can access the malware-detection service.
+          - Log in to the console as a member of the *Sysadmins* group, and confirm that you can access Red Hat Insights services for managing RHEL systems.
+
+        failedTaskHelp: Try completing the steps again.
+      # optional - the task's success and failure messages
+      summary:
+        success: Shows a success message in the task header
+        failed: Shows a failed message in the task header
+
+    - title: (Optional) Creating additional groups as needed
+      description: |-
+        Create additional groups to fine-tune user access to specific services as needed. Add any team members to this group who need those permissions.
+        
+        1. Click **Groups** > **Create group**.
+
+        2. Enter a group name and description, and click **Next**.
+
+        3. Add the roles required per service and click **Next**.
+
+        4. Add any users to the group who need those permissions. Select the checkboxes for those users and click **Next**.
+
+        5. Review the group details and click **Submit** to create the group.
+
+      # optional - the task's Check your work module
+      review:
+        instructions: |-
+          - Log in to the console as a member of your new group and confirm the access you configured allows you to view or edit resources for the service as desired.
+
+        failedTaskHelp: Try completing the steps again.
+      # optional - the task's success and failure messages
+      summary:
+        success: Shows a success message in the task header
+        failed: Shows a failed message in the task header
+  
+  conclusion: |-
+    Congratulations! You have now configured granular access to services for 2 teams in your organization, and removed default access for other users.
+    
+    After completing this quick start:
+    - Users in the *Security Team* group can perform malware-detection tasks.
+    - Users in the *Sysadmins* group can view and edit RHEL resources and services in the console, except for malware detection.
+    - Other users in your organization cannot view any services or resources in the console.
+
+    A few tips:
+    - User access in the console is additive, meaning that each user has the default access permissions, plus permissions from any other groups they are assigned.
+    - You can undo any changes you make to the **Default access** group by clicking **Restore to default** on the **Groups** page.
+
+    From here, you can use this example to continue creating additional groups with access to specific services.
+
+    **Learn more:**
+      - See the [User Access Configuration Guide for Role-based Access Control (RBAC)](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/user_access_configuration_guide_for_role-based_access_control_rbac/index) and [Restricting service access to a single user](https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/user_access_configuration_guide_for_role-based_access_control_rbac/assembly-rbac-procedures#proc-rbac-restricting-access_rbac-intro)
+


### PR DESCRIPTION
This is a new quickstart for User Access (https://issues.redhat.com/browse/HCCDOC-334), which originally was going to go on the Learning resources page for Settings, but now needs to go into the IAM Learning resources (once created) as users will configure User Access settings from there.

RHCLOUD JIra: https://issues.redhat.com/browse/RHCLOUD-24721

@Hyperkid123 or @ryelo - can you please review and merge/let me know if anything needs fixing? Thank you!