### PR TITLE
RHTAPBUGS-118: fix link and product name

### DIFF
--- a/docs/help-topics/appstudio-settings/appstudio-settings.yml
+++ b/docs/help-topics/appstudio-settings/appstudio-settings.yml
@@ -10,7 +10,7 @@
 
     What you might want to remember on your journey:
 
-    - The **Development environment** is included with App Studio by default. You can create as many other environments as you need.
+    - The **Development environment** is included with our service by default. You can create as many other environments as you need.
 
     - Each environment is available for all your applications.
 
@@ -18,7 +18,7 @@
 
     - **Environment links** are generated automatically and allow access to your apps deployed to that environment.
 
-    - Automatic and manual **deployment strategies** set how App Studio treats updates you make to your code. With the **automatic strategy**, all component updates are automatically deployed to the environment, then updated components are automatically promoted to the subsequent environments where they were deployed before. With the **manual strategy**, manual steps are required to redeploy and promote updated components.
+    - Automatic and manual **deployment strategies** set how our service treats updates that you make to your code. With the **automatic strategy**, all component updates are automatically deployed to the environment, then updated components are automatically promoted to the subsequent environments where they were deployed before. With the **manual strategy**, manual steps are required to redeploy and promote updated components.
 
     >**NOTE**: When you promote a component to the next environment, the current deployment strategy is used in the destination environment. However, you can change a strategy while promoting components.
 

--- a/docs/help-topics/stonesoup-whatsnext/stonesoup-whatsnext.yml
+++ b/docs/help-topics/stonesoup-whatsnext/stonesoup-whatsnext.yml
@@ -42,7 +42,7 @@
   content: |-
     To customize your build pipelines, install the GitHub app. After you install the GitHub app, it creates webhooks for your repositories and running builds. The GitHub app also tests your pull requests for you to view before merging your pull requests. 
 
-    1. Go to the GitHub repository: [https://github.com/apps/appstudio-staging-ci/](https://github.com/apps/appstudio-staging-ci/). 
+    1. Go to the GitHub repository: [https://github.com/apps/rh-trusted-application-pipeline](https://github.com/apps/rh-trusted-application-pipeline). 
     2. Select **Install GitHub App**. 
     3. Select which of your repositories you want the GitHub app to have access to. 
     4. If you do not grant the GitHub app access to your repository, you must manually select each component for the GitHub app to access. 


### PR DESCRIPTION
This PR fixes a link from [RHTAPBUGS-118](https://issues.redhat.com/browse/RHTAPBUGS-118) and also removes an outdated product name as was requested on Slack: [forum-hac-docs](https://redhat-internal.slack.com/archives/C03494X9Y2U/p1682370101996679).
Will appreciate your review @Hyperkid123, thank you.