### PR TITLE
Add settings bundle to metadata as well

### DIFF
--- a/docs/quickstarts/rbac-admin-vuln-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-admin-vuln-permissions/metadata.yml
@@ -5,3 +5,5 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
+  - kind: bundle
+    value: settings

--- a/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
+++ b/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
@@ -5,4 +5,6 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
+  - kind: bundle
+    value: settings
     

--- a/docs/quickstarts/rbac-read-only-vuln-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-read-only-vuln-permissions/metadata.yml
@@ -5,4 +5,6 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
+  - kind: bundle
+    value: settings
     

--- a/docs/quickstarts/rbac-reducing-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-reducing-permissions/metadata.yml
@@ -5,4 +5,6 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
+  - kind: bundle
+    value: settings
     


### PR DESCRIPTION
Hi @Hyperkid123 ,
Apologies for another PR (hopefully the last one for now) - the docs team realized that moving the RBAC quickstarts to the IAM page leaves the Settings quickstarts empty, and users still may be looking for User Access on the Settings page as it's a recent change. Our conclusion is it's best to show these quickstarts on both the IAM and Settings Learning Resources.

I added the `settings` bundle tag as well to each metadata.yml file per quickstart to allow them appear in both places (hopefully this is correct).

Thank you for all your help - I appreciate it!
-Dayle