### PR TITLE
Fixed Ansible docs link in console

### DIFF
--- a/docs/quickstarts/ansible-related-documentation/ansible-related-documentation.yml
+++ b/docs/quickstarts/ansible-related-documentation/ansible-related-documentation.yml
@@ -12,5 +12,5 @@ spec:
   icon: ~
   description: A complete list of documentation related to  Ansible Automation Platform services.
   link:
-    href: https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/2.3
+    href: https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/
     text: View Documentation


### PR DESCRIPTION
See https://issues.redhat.com/browse/HCCDOC-1137

Updated the Ansible docs link in the Related Documentation tile , so it goes to the main docs splash page without a version (this will redirect to the latest version).

@Hyperkid123 @ryelo @karelhala - would your team mind reviewing and merging, please?
Thank you!