### PR TITLE
Update README.md - lowercase openshift tag

### DIFF
--- a/docs/quickstarts/README.md
+++ b/docs/quickstarts/README.md
@@ -216,7 +216,7 @@ See the below list for the value tags to use for each bundle:
 | Bundle  |  value tag |
 |---|---|
 |  Application & Data Services | application-services  |
-|  OpenShift |  OpenShift |
+|  OpenShift |  openshift |
 |  Ansible Automation Platform | ansible  |
 | Red Hat Insights  | insights  |
 | Edge management  | edge  |


### PR DESCRIPTION
We had OpenShift capitalized in the bundle tags list which was incorrect - I've edited this based on Martin's comment in https://github.com/RedHatInsights/quickstarts/pull/145/files

@Hyperkid123 if this update makes sense to you, could you please merge?
Thanks!