### PR TITLE
Rename Sources to Integrations in launch guide

### DIFF
--- a/docs/quickstarts/insights-launch-aws/insights-launch-aws.yml
+++ b/docs/quickstarts/insights-launch-aws/insights-launch-aws.yml
@@ -23,21 +23,21 @@ spec:
   introduction: |-
     Welcome to the quick start for launching an Amazon Web Service (AWS) image.
 
-    In this quick start, you learn how to add or edit &nbsp;[AWS sources] (https://console.redhat.com/beta/settings/sources), create an image, and launch it all on the Red Hat Hybrid Cloud Console.
+    In this quick start, you learn how to add or edit &nbsp;[AWS Integrations] (https://console.redhat.com/settings/integrations), create an image, and launch it all on the Red Hat Hybrid Cloud Console.
 
   tasks:
-    - title: Add or edit an AWS Source
+    - title: Add or edit an AWS Integration
       description: |-
         
-        A source must be configured to connect your AWS account to Hybrid Cloud Console to launch an Image. Create a new source or edit an existing one.
+        An Integration must be configured to connect your AWS account to Hybrid Cloud Console to launch an Image. Create a new integration or edit an existing one.
         <br>
         <br>
 
-        <h4 id="add-aws-source"><b>Add an AWS Source:</B></h4> 
+        <h4 id="add-aws-source"><b>Add an AWS Integration:</B></h4> 
         
         1. Click the Settings <i class="fas fa-cog"></i> icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
 
         1. Click **Add source**.
 
@@ -79,11 +79,11 @@ spec:
         <br>
         
         
-        <h4 id="edit-aws-source"><b>Edit an existing AWS Source:</B></h4>
+        <h4 id="edit-aws-source"><b>Edit an existing AWS Integration:</B></h4>
 
         1. Click the Settings icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
         
         1. Locate your existing AWS source in the cloud sources table
         

--- a/docs/quickstarts/insights-launch-azure/insights-launch-azure.yml
+++ b/docs/quickstarts/insights-launch-azure/insights-launch-azure.yml
@@ -19,17 +19,18 @@ spec:
   # - If set to null (icon: ~) will not show an icon
   icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
   description: |-
-    Learn how to add an Microsoft Azure source and launch an image.
+    Learn how to add an Microsoft Azure integration and launch an image.
   introduction: |-
-    Welcome to the quick start for launching an Micorsoft Azure image.
+    Welcome to the quick start for launching an Microsoft Azure image.
 
-    In this quick start, you learn how to add or edit Azure sources, create an image, and launch it all on the Red Hat Hybrid Cloud Console.
+    In this quick start, you learn how to add or edit Azure integrations, create an image, and launch it all on the Red Hat Hybrid Cloud Console.
 
   tasks:
-    - title: Add or Edit an Azure source
+    - title: Add or Edit an Azure integration
       description: |-
         
-        A source must be configured to connect your Azure account to Hybrid Cloud Console to launch an image. Create a new source or edit an existing one.
+        An integration must be configured to connect your Azure account to Hybrid Cloud Console to launch an image.
+        Create a new integration or edit an existing one.
         <br>
         <br>
 
@@ -37,7 +38,7 @@ spec:
         
         1. Click the Settings <i class="fas fa-cog"></i> icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
 
         1. Click **Add source**.
 
@@ -78,7 +79,7 @@ spec:
 
         1. Click the Settings icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
         
         1. Locate your existing Azure source in the cloud sources table
         
@@ -87,6 +88,14 @@ spec:
         1. Locate the “Applications” card.
         
         1. Toggle “Launch images” to **on**.
+
+        1. In the modal that opens, click the **Take me to Lighthouse** button.
+
+        1. When done in Azure portal, click **Next**
+
+        1. Copy the subscription ID for which you've settup the connection in Azure portal.
+
+        1. Confirm with **Add**
 
         It will take a few moments to apply the configuration.
         <br>

--- a/docs/quickstarts/insights-launch-gcp/insights-launch-gcp.yml
+++ b/docs/quickstarts/insights-launch-gcp/insights-launch-gcp.yml
@@ -23,21 +23,21 @@ spec:
   introduction: |-
     Welcome to the quick start for launching a Google Cloud Platform (GCP) image.
 
-    In this quick start, you learn how to add or edit &nbsp;[GCP sources] (https://console.redhat.com/beta/settings/sources), create an image, and launch it all on the Red Hat Hybrid Cloud Console.
+    In this quick start, you learn how to add or edit &nbsp;[GCP integrations] (https://console.redhat.com/settings/integrations), create an image, and launch it all on the Red Hat Hybrid Cloud Console.
 
   tasks:
-    - title: Add or edit a GCP Source
+    - title: Add or edit a GCP Integration
       description: |-
         
-        A source must be configured to connect your GCP account to Hybrid Cloud Console to launch an Image. Create a new source or edit an existing one.
+        An Integration must be configured to connect your GCP account to Hybrid Cloud Console to launch an Image. Create a new integration or edit an existing one.
         <br>
         <br>
 
-        <h4 id="add-GCP-source"><b>Add a GCP Source:</B></h4> 
+        <h4 id="add-GCP-source"><b>Add a GCP Integration:</B></h4> 
         
         1. Click the Settings <i class="fas fa-cog"></i> icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
 
         1. Click **Add source**.
 
@@ -75,11 +75,11 @@ spec:
         <br>
         
         
-        <h4 id="edit-GCP-source"><b>Edit an existing GCP Source:</B></h4>
+        <h4 id="edit-GCP-source"><b>Edit an existing GCP Integration:</B></h4>
 
         1. Click the Settings icon in the top right corner.
 
-        1. In Settings, click **Sources** in the left menu.
+        1. In Settings, click **Integrations** in the left menu.
         
         1. Locate your existing GCP source in the cloud sources table
         
@@ -88,6 +88,12 @@ spec:
         1. Locate the “Applications” card.
         
         1. Toggle “Launch images” to **on**.
+
+        1. In the modal, fill out a GCP project ID you want to use and click **Next**.
+
+        1. Follow the guide on how to set-up the role in GCP project.
+
+        1. Confirm with **Add**
         <br>
         <br>
 


### PR DESCRIPTION
Corrects the Sources references in the launch guides where necessary. Also fixes editing of Azure and GCP source.

https://issues.redhat.com/browse/CRCFEEDBK-2670