### PR TITLE
Moved all User Access related quick starts to the IAM LR page

### DIFF
--- a/docs/quickstarts/insights-inventory-groups-rbac/metadata.yml
+++ b/docs/quickstarts/insights-inventory-groups-rbac/metadata.yml
@@ -6,6 +6,6 @@ tags:
   - kind: application
     value: inventory
   - kind: bundle
-    value: settings
+    value: iam
   - kind: application
     value: rbac

--- a/docs/quickstarts/insights-inventory-groups/metadata.yml
+++ b/docs/quickstarts/insights-inventory-groups/metadata.yml
@@ -6,7 +6,7 @@ tags:
   - kind: application
     value: inventory
   - kind: bundle
-    value: settings
+    value: iam
   - kind: application
     value: user access
     

--- a/docs/quickstarts/rbac-admin-vuln-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-admin-vuln-permissions/metadata.yml
@@ -5,5 +5,3 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
-  - kind: bundle
-    value: settings

--- a/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
+++ b/docs/quickstarts/rbac-granular-malware-rhel-access/metadata.yml
@@ -5,6 +5,4 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
-  - kind: bundle
-    value: settings
-    
+ 

--- a/docs/quickstarts/rbac-read-only-vuln-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-read-only-vuln-permissions/metadata.yml
@@ -5,6 +5,5 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
-  - kind: bundle
-    value: settings
+
     

--- a/docs/quickstarts/rbac-reducing-permissions/metadata.yml
+++ b/docs/quickstarts/rbac-reducing-permissions/metadata.yml
@@ -5,6 +5,5 @@ tags: # If you want to use more granular filtering add tags to the quickstart
     value: iam
   - kind: application # use application tag for quickstart used by specific application
     value: my-user-access
-  - kind: bundle
-    value: settings
+
     


### PR DESCRIPTION
RHCLOUD Jira: https://issues.redhat.com/browse/RHCLOUD-29444

- Removed all RBAC and Inventory group quickstarts from the Settings page, as the steps need to be done from Settings > IAM.
- Added the missing inventory groups quickstarts to the Settings > IAM page

More details in https://issues.redhat.com/browse/HCCDOC-849

Thank you for reviewing & merging, @Hyperkid123 @ryelo @karelhala 