### PR TITLE
Create Learning Resources card for RHACS

### DIFF
--- a/docs/quickstarts/acs-getting-started-acscs/acs-getting-started-acscs.yml
+++ b/docs/quickstarts/acs-getting-started-acscs/acs-getting-started-acscs.yml
@@ -1,0 +1,16 @@
+apiVersion: console.openshift.io/v1
+kind: QuickStarts
+metadata:
+  name: acs-getting-started-acscs
+  externalDocumentation: true
+spec:
+  version: 0.1
+  type:
+    text: Documentation
+    color: orange
+  displayName: Learn about Red Hat Advanced Cluster Security
+  icon:
+  description: Secure all your hybrid cloud clusters.
+  link:
+    href: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/
+    text: View documentation

--- a/docs/quickstarts/acs-getting-started-acscs/metadata.yml
+++ b/docs/quickstarts/acs-getting-started-acscs/metadata.yml
@@ -1,0 +1,5 @@
+kind: QuickStarts # kind must always be "QuickStarts"
+name: acs-getting-started-acscs
+tags: # If you want to use more granular filtering add tags to the quickstart
+  - kind: bundle
+    value: application-services


### PR DESCRIPTION
@Hyperkid123 or @ryelo

Doron Caspin asked that we add a Documentation link tile for Red Hat Advanced Cluster Security.

Kerry Carmichael supplied the permalink I used for this card,
https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/
which will link to the latest version of the docs for RHACS.

Here is a preview of the card I created with the Preview Tool:
![Screenshot 2024-03-29 at 10 59 55 AM](https://github.com/RedHatInsights/quickstarts/assets/715729/1828ef89-4054-439a-872e-078c2df50a45)

Note: I specified the **Application Services > Learning Resources** page for the location of this tile. A preview of that current page is below. This is the section where Advanced Cluster Security appears in console.redhat.com.

If we want the card to appear instead, or in addition to, in **OpenShift > Learning Resources**, I can make that change in this PR before it is merged.

![Screenshot 2024-03-29 at 11 04 44 AM](https://github.com/RedHatInsights/quickstarts/assets/715729/a9bd0f6a-bb65-484e-9aa9-6f8346751c4a)
