### PR TITLE
Updated links for GA docs

### DIFF
--- a/docs/quickstarts/tpa-scanning-an-sbom-file/tpa-scanning-an-sbom-file.yml
+++ b/docs/quickstarts/tpa-scanning-an-sbom-file/tpa-scanning-an-sbom-file.yml
@@ -14,5 +14,5 @@ spec:
   description: |-
     Learn how to scan a software bill of materials (SBOM) file for analysis by using the Red Hat Trusted Profile Analyzer service.
   link:
-    href: https://access.redhat.com/documentation/en-us/red_hat_trusted_profile_analyzer/2023-q4/html/quick_start_guide/scanning-an-sbom-file_tc-qsg
+    href: https://access.redhat.com/documentation/en-us/red_hat_trusted_profile_analyzer/1/html/quick_start_guide/scanning-an-sbom-file_qsg
     text: View documentation 

--- a/docs/quickstarts/tpa-searching-for-vulnerability-information/tpa-searching-for-vulnerability-information.yml
+++ b/docs/quickstarts/tpa-searching-for-vulnerability-information/tpa-searching-for-vulnerability-information.yml
@@ -14,5 +14,5 @@ spec:
   description: |-
     Learn how to search for vulnerability information by using the Red Hat Trusted Profile Analyzer service.
   link: 
-    href: https://access.redhat.com/documentation/en-us/red_hat_trusted_profile_analyzer/2023-q4/html/quick_start_guide/searching-for-vulnerability-information_tc-qsg
+    href: https://access.redhat.com/documentation/en-us/red_hat_trusted_profile_analyzer/1/html/quick_start_guide/searching-for-vulnerability-information_qsg
     text: View documentation


### PR DESCRIPTION
Red Hat Trusted Profile Analyzer has gone GA today, May 2nd.  I've updated the links in the TPA quick starts to point to the latest documentation.