### PR TITLE
Use public RH registry to download docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/rhel8/go-toolset:1.20.12-5.1712568462 AS builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-5.1712568462 AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 go build -buildvcs=false -o /go/bin/quickstarts
 RUN CGO_ENABLED=0 go build -o /go/bin/quickstarts-migrate cmd/migrate/migrate.go
 
  
-FROM registry.redhat.io/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi8-minimal:latest
 
 COPY --from=builder /go/bin/quickstarts /usr/bin
 COPY --from=builder /go/bin/quickstarts-migrate /usr/bin


### PR DESCRIPTION
Fixes the 401 errors while running the security workflows in GH actions