### PR TITLE
[RHCLOUD-30197] Use Konflux built image

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -84,7 +84,7 @@ parameters:
   required: true
 - description: Image name
   name: IMAGE
-  value: quay.io/cloudservices/quickstarts
+  value: quay.io/redhat-services-prod/hcc-platex-services/quickstarts
 - description: Determines Clowder deployment
   name: CLOWDER_ENABLED
   value: "false"


### PR DESCRIPTION
* Removes `cloudservices` image in favor of `hcc-platex-services` image