### PR TITLE
RHINENG-10656: Add info about task conversion parameters

### DIFF
--- a/docs/quickstarts/insights-tasks-conversion/insights-tasks-conversion.yml
+++ b/docs/quickstarts/insights-tasks-conversion/insights-tasks-conversion.yml
@@ -44,7 +44,20 @@ spec:
         1. Go to **Red Hat Insights > RHEL > Automation Toolkit > Tasks.**
         1. Locate the **Convert to RHEL from CentOS 7 Linux** task and click **Select systems.**
         1. You can change the task name. It will be used on the report generated. 
-        1. Select the CentOS Linux 7 systems you want to convert to RHEL and click  **Run task.**
+        1. Select the CentOS Linux 7 systems you want to convert to RHEL and click  **Next.**
+        1. Configure the conversion task with the given settings, as required.
+          <details>
+            <summary><span style="color:#0066CC">&nbsp**Configurable task settings**</span></summary>
+            - **Do not use the ELS subscription**<br>
+              Choose this option if you plan to upgrade your RHEL system to version 8 or higher.
+            - **Allow kernel modules outside of RHEL repositories on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore kernel modules that are not part of RHEL repositories.
+            - **Allow outdated kernel on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore when your system is booted from an outdated kernel.
+            - **Allow outdated packages on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore all outdated packages on the system.
+          </details>
+        1. Click **Run Task** to start the conversion task on the selected systems.
         1. Go to the **Activity tab** and find the newly running conversion task. Your task shows a run status of "Running" until it finishes for all included systems. At that time the run status will update to "Completed."
         
         [The conversion process can take up to an hour to complete.]{{admonition note}}

--- a/docs/quickstarts/insights-tasks-pre-conversion/insights-tasks-pre-conversion.yml
+++ b/docs/quickstarts/insights-tasks-pre-conversion/insights-tasks-pre-conversion.yml
@@ -86,7 +86,7 @@ spec:
 
         1. You can change the task name. It will be used on the report generated. 
 
-        1. Select the CentOS Linux 7 systems you want to analyze for conversion and click **Run task.**
+        1. Select the CentOS Linux 7 systems you want to analyze for conversion and click **Next.**
           <details>
             <summary><span style="color:#0066CC">&nbsp**Don't see your system?**</span></summary>
             <br>
@@ -139,7 +139,19 @@ spec:
               ```{{copy}}
              
           </details>
-        
+        1. Configure the pre-conversion analysis task with the given settings, as required.
+          <details>
+            <summary><span style="color:#0066CC">&nbsp**Configurable task settings**</span></summary>
+            - **Do not use the ELS subscription**<br>
+              Choose this option if you plan to upgrade your RHEL system to version 8 or higher.
+            - **Allow kernel modules outside of RHEL repositories on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore kernel modules that are not part of RHEL repositories.
+            - **Allow outdated kernel on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore when your system is booted from an outdated kernel.
+            - **Allow outdated packages on the system**<br>
+              Choose this option to allow the pre-conversion analysis to ignore all outdated packages on the system.
+          </details>
+        1. Click **Run Task** to start the pre-conversion task on the selected systems.
         1. Go to the **Activity** tab and find the newly running conversion task. Your task shows a run status of "Running" until it finishes for all included systems. At that time, the run status will update to "Completed."
           
         [The pre-conversion analysis can take up to an hour to complete.]{{admonition note}}   


### PR DESCRIPTION
Screenshots showing the changes to the quickstarts for the pre-conversion and conversion tasks:
![Screenshot from 2024-08-21 11-31-11](https://github.com/user-attachments/assets/9d3f72dc-6e70-412b-8e9e-42162f37a53a)
![Screenshot from 2024-08-21 11-31-40](https://github.com/user-attachments/assets/7eba9a84-2513-4d02-acb4-23b97744c47a)
