### PR TITLE
RHCLOUD-35342 - Fixes outdated link in the Edge Learning Resources tiles

### DIFF
--- a/docs/quickstarts/edge-create-image/edge-create-image.yml
+++ b/docs/quickstarts/edge-create-image/edge-create-image.yml
@@ -13,5 +13,5 @@ spec:
   icon: ~
   description: Build, download, and install an image on a system and then register that system to receive updates.
   link:
-    href: https://access.redhat.com/documentation/en-us/edge_management/2022/html-single/create_rhel_for_edge_images_and_configure_automated_management/index
+    href: https://docs.redhat.com/en/documentation/edge_management/1-latest/html/create_rhel_for_edge_images_and_configure_automated_management/index
     text: View documentation

--- a/docs/quickstarts/edge-custom-images/edge-custom-images.yml
+++ b/docs/quickstarts/edge-custom-images/edge-custom-images.yml
@@ -9,9 +9,9 @@ spec:
   type:
     text: Documentation
     color: orange
-  displayName: Creating customized images using the Image Builder service
+  displayName: Deploying and managing RHEL systems in hybrid clouds
   icon: ~
   description: Create a customized image and upload the image to target cloud environments.
   link:
-    href: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_rhel_images_using_the_image_builder_service
+    href: https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/deploying_and_managing_rhel_systems_in_hybrid_clouds/index
     text: View documentation

--- a/docs/quickstarts/edge-manage-systems/edge-manage-systems.yml
+++ b/docs/quickstarts/edge-manage-systems/edge-manage-systems.yml
@@ -13,5 +13,5 @@ spec:
   icon: ~
   description: Group, connect, and manage edge systems after registering them with the edge management console.
   link:
-    href: https://access.redhat.com/documentation/en-us/edge_management/2022/html-single/working_with_systems_in_the_edge_management_application/index
+    href: https://docs.redhat.com/en/documentation/edge_management/1-latest/html/working_with_systems_in_the_insights_inventory_application/index
     text: View documentation

--- a/docs/quickstarts/edge-related-docs/edge-related-docs.yml
+++ b/docs/quickstarts/edge-related-docs/edge-related-docs.yml
@@ -13,5 +13,5 @@ spec:
   icon: ~
   description: A complete list of documentation related to edge management.
   link:
-    href: https://access.redhat.com/documentation/en-us/edge_management
+    href: https://docs.redhat.com/en/documentation/edge_management/1-latest/
     text: View documentation


### PR DESCRIPTION
The documentation team received a feedback informing that some links in the https://console.redhat.com/edge/learning-resources were link to a 404 page.

This PR fixes the broken links, by updating them to the latest version.