### PR TITLE
HCCDOC-3146a - Edit the display name of API cheatsheet

### DIFF
--- a/docs/quickstarts/insights-api-cheatsheet/insights-api-cheatsheet.yml
+++ b/docs/quickstarts/insights-api-cheatsheet/insights-api-cheatsheet.yml
@@ -8,7 +8,7 @@ spec:
   type:
     text: Documentation
     color: orange
-  displayName: Insights API Cheatsheet
+  displayName: API Cheatsheet
   icon: ~
   description: Obtain system details and interact with individual Insights services.
   link:


### PR DESCRIPTION
The team made the decision to change the display name on the learning resources tile to better align with the existing naming convention and for usability.

"Insights API cheatsheet" changed to "API Cheatsheet"