### PR TITLE
Edited metadata for Settings LRs for global LR page

### DIFF
--- a/docs/quickstarts/common-access-rh-com/metadata.yml
+++ b/docs/quickstarts/common-access-rh-com/metadata.yml
@@ -8,6 +8,10 @@ tags:
 - kind: content
   value: documentation
 - kind: product-families
-  value: openshift
+  value: settings
+- kind: product-families
+  value: iam
 - kind: use-case
-  value: clusters
+  value: system-configuration
+- kind: use-case
+  value: identity-and-access

--- a/docs/quickstarts/settings-configuring-cloud-integrations/metadata.yml
+++ b/docs/quickstarts/settings-configuring-cloud-integrations/metadata.yml
@@ -7,6 +7,12 @@ tags:
   value: documentation
 - kind: product-families
   value: settings
+- kind: product-families
+  value: rhel 
+- kind: product-families
+  value: ansible 
+- kind: product-families
+  value: openshift
 - kind: use-case
   value: system-configuration
 

--- a/docs/quickstarts/settings-configuring-cloud-integrations/settings-configuring-cloud-integrations.yml
+++ b/docs/quickstarts/settings-configuring-cloud-integrations/settings-configuring-cloud-integrations.yml
@@ -10,7 +10,7 @@ spec:
     color: orange
   displayName: Configuring cloud integrations for Red Hat services
   icon: ~
-  description: How to link your Red Hat account to a public cloud
+  description: How to link your Red Hat account to a public cloud.
   link:
     href: https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/configuring_cloud_integrations_for_red_hat_services/index
     text: View documentation

--- a/docs/quickstarts/settings-configuring-notifications-integrations/metadata.yml
+++ b/docs/quickstarts/settings-configuring-notifications-integrations/metadata.yml
@@ -8,7 +8,11 @@ tags:
 - kind: product-families
   value: settings
 - kind: product-families
-  value: rhel  
+  value: rhel 
+- kind: product-families
+  value: ansible 
+- kind: product-families
+  value: openshift
 - kind: use-case
   value: automation
 - kind: use-case

--- a/docs/quickstarts/settings-hcc-getting-started/metadata.yml
+++ b/docs/quickstarts/settings-hcc-getting-started/metadata.yml
@@ -7,6 +7,16 @@ tags:
   value: documentation
 - kind: product-families
   value: settings
+- kind: product-families
+  value: rhel  
+- kind: product-families
+  value: iam
+- kind: product-families
+  value: ansible 
+- kind: product-families
+  value: openshift
+- kind: product-families
+  value: subscriptions-services
 - kind: use-case
   value: identity-and-access
 - kind: use-case

--- a/docs/quickstarts/settings-integration-third-party-apps/metadata.yml
+++ b/docs/quickstarts/settings-integration-third-party-apps/metadata.yml
@@ -11,6 +11,10 @@ tags:
   value: settings
 - kind: product-families
   value: rhel
+- kind: product-families
+  value: ansible 
+- kind: product-families
+  value: openshift
 - kind: use-case
   value: automation
 - kind: use-case


### PR DESCRIPTION
Reviewed the metadata tags for the learning resources on the Settings > Learning resources page.
Added and edited a few tags as appropriate.

Mostly, broadened the scope of the Getting Started Guide so it will appear in any product family.
Edit: After discussing with notifications/integrations PM, we determined it would help users to have these cards appear when filtering for each product family - added more product families.

Jira: [HCCDOC-3269](https://issues.redhat.com/browse/HCCDOC-3269)
