### PR TITLE
Added product-families tag for RHTPA quickstarts

### DIFF
--- a/docs/quickstarts/tpa-scanning-an-sbom-file/metadata.yml
+++ b/docs/quickstarts/tpa-scanning-an-sbom-file/metadata.yml
@@ -5,6 +5,8 @@ tags:
   value: application-services
 - kind: content
   value: documentation
+- kind: product-families
+  value: openshift
 - kind: use-case
   value: data-services
 - kind: use-case

--- a/docs/quickstarts/tpa-searching-for-vulnerability-information/metadata.yml
+++ b/docs/quickstarts/tpa-searching-for-vulnerability-information/metadata.yml
@@ -5,6 +5,8 @@ tags:
   value: application-services
 - kind: content
   value: documentation
+- kind: product-families
+  value: openshift
 - kind: use-case
   value: data-services
 - kind: use-case


### PR DESCRIPTION
Added the mandatory `product-families` tag to the Trusted Profile Analyzer `metadata.yml` file for both published quickstarts.