### PR TITLE
Edits metadata for cost mgmt yamls

### DIFF
--- a/docs/quickstarts/openshift-cost-explorer/metadata.yml
+++ b/docs/quickstarts/openshift-cost-explorer/metadata.yml
@@ -2,7 +2,7 @@ kind: QuickStarts
 name: openshift-cost-explorer
 tags:
 - kind: bundle
-  value: openshift
+  value: insights
 - kind: content
   value: documentation
 - kind: product-families

--- a/docs/quickstarts/openshift-cost-management-access/metadata.yml
+++ b/docs/quickstarts/openshift-cost-management-access/metadata.yml
@@ -2,7 +2,7 @@ kind: QuickStarts
 name: openshift-cost-management-access
 tags:
 - kind: bundle
-  value: openshift
+  value: insights
 - kind: content
   value: documentation
 - kind: product-families

--- a/docs/quickstarts/openshift-cost-management/metadata.yml
+++ b/docs/quickstarts/openshift-cost-management/metadata.yml
@@ -2,13 +2,14 @@ kind: QuickStarts
 name: openshift-cost-management
 tags:
 - kind: bundle
-  value: openshift
+  value: insights
 - kind: content
   value: documentation
 - kind: product-families
   value: openshift
 - kind: use-case
-  value: containers
+  value: clusters
 - kind: use-case
   value: spend-management
-   
+- kind: use-case
+  value: data-services

--- a/docs/quickstarts/openshift-cost-models/metadata.yml
+++ b/docs/quickstarts/openshift-cost-models/metadata.yml
@@ -2,7 +2,7 @@ kind: QuickStarts
 name: openshift-cost-models
 tags:
 - kind: bundle
-  value: openshift
+  value: insights
 - kind: content
   value: documentation
 - kind: product-families
@@ -11,3 +11,5 @@ tags:
   value: subscriptions-services
 - kind: use-case
   value: spend-management  
+- kind: use-case
+  value: system-configuration

--- a/docs/quickstarts/openshift-cost-tagging/metadata.yml
+++ b/docs/quickstarts/openshift-cost-tagging/metadata.yml
@@ -2,7 +2,7 @@ kind: QuickStarts
 name: openshift-cost-tagging
 tags:
 - kind: bundle
-  value: openshift
+  value: insights
 - kind: content
   value: documentation
 - kind: product-families
@@ -11,3 +11,5 @@ tags:
   value: subscriptions-services
 - kind: use-case
   value: spend-management  
+- kind: use-case
+  value: system-configuration 


### PR DESCRIPTION
Edited the metadata for cost mgmt. One change you'll have to let me know about is I changed openshift to insights. Cost is "Red Hat Insights cost management" so that seemed more appropriate to me. 

[HCCDOC-3315](https://issues.redhat.com/browse/HCCDOC-3315)