### PR TITLE
OSDOCS-13602:Updated add ocm role access quickstart to include OSD.

### DIFF
--- a/docs/quickstarts/rosa-osd-grant-ocm-role-access/metadata.yml
+++ b/docs/quickstarts/rosa-osd-grant-ocm-role-access/metadata.yml
@@ -1,5 +1,5 @@
 kind: QuickStarts
-name: rosa-grant-ocm-role-access
+name: rosa-osd-grant-ocm-role-access
 tags:
   - kind: bundle
     value: openshift

--- a/docs/quickstarts/rosa-osd-grant-ocm-role-access/rosa-osd-grant-ocm-role-access.yml
+++ b/docs/quickstarts/rosa-osd-grant-ocm-role-access/rosa-osd-grant-ocm-role-access.yml
@@ -1,42 +1,44 @@
 
 metadata:
-  name: rosa-grant-ocm-role-access
+  name: rosa-osd-grant-ocm-role-access
   instructional: true
 spec:
-  displayName: Add OCM roles and access to ROSA clusters
+  displayName: Adding OCM roles and access to managed OpenShift clusters
   durationMinutes: 5
   type:
     text: Quick start
     color: green
   icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
   prerequisites:
-    - You must have access to a ROSA cluster.
+    - You must have access to a ROSA or OSD cluster.
     - You must be a cluster owner, cluster editor, or Organization Administrator for the cluster.
     - You must know the user identifier of the person that you want to add.
 
 
   description: |-
-    Adding OCM roles and access to cluster users.
+    Add OCM roles and access to cluster users.
   introduction: |-
-    If you create or manage a cluster, you can add additional OCM roles and access to users of that cluster. The user who created the cluster or users with specific permissions can add the OCM roles and access to a cluster.
+    If you create or manage a cluster, you can add additional OpenShift Cluster Manager (OCM) roles and access to users of that cluster. You can specify which specific permissions you want to give these users. These permissions only apply to cluster management in OCM.
 
-    In this quick start, you'll add OCM roles and access to clusters for your cluster users.
+    In this quick start, you'll allow a user in your organization to manage and configure a cluster by granting them the Cluster editor role for that cluster.
+
+    [In this quickstart, when we refer to ROSA, we are referring to both ROSA (classic architecture) and ROSA with HCP, and when we refer to OSD, we are referring to both OSD on GCP and OSD on AWS.]{{admonition note}}
 
   tasks:
-    - title: Add OCM roles and access to your cluster
+    - title: Grant OCM role to a user in your organization
       description: |-
-        To edit your cluster's name:
+        To add OCM roles and grant access to users of a cluster:
 
         1. Go to **Cluster List**.
-        1. Click your cluster's name to view cluster details.
+        1. Click your cluster's name to view the cluster details.
         1. Click the **Access control** tab.
         1. Click the **OCM Roles and Access** tab.
         1. Click the **Grant role** button.
         1. Enter the Red Hat login for the user.
-        1. Select the role you want (for example, Cluster Viewer) from the list.
+        1. Select the **Cluster editor** role from the list.
         1. Click **Grant role**.
 
-        Your cluster user now has the added OCM role and access for that user has now changed.
+        Your cluster user now has the Cluster editor role and access for that user has now changed.
 
   # optional - the task's Check your work module
       review:
@@ -51,4 +53,7 @@ spec:
         Congratulations, you added OCM roles and access for your users to your cluster!
 
         Repeat the steps to add more OCM roles and configure access if you desire.
+
+        If you want to remove a user you've just granted an OCM role to, click the options icon (⋮) > Delete next to that user.
+
   # you can link to the next quick start(s) here


### PR DESCRIPTION
This PR is to update the _Add OCM roles and access to ROSA clusters_ quick start by

- Ensuring the quick start is also relevant for users of OSD clusters
- Updating the title, file title, and metadata accordingly

Issues:

OSDOCS:
https://issues.redhat.com/browse/OSDOCS-13588

RHCLOUD:
https://issues.redhat.com/browse/RHCLOUD-38802