### PR TITLE
OSDOCS-13604:Amended ROSA cluster autoscaling quickstart to also refer to OSD.

### DIFF
--- a/docs/quickstarts/rosa-osd-edit-cluster-autoscaling/metadata.yml
+++ b/docs/quickstarts/rosa-osd-edit-cluster-autoscaling/metadata.yml
@@ -1,5 +1,5 @@
 kind: QuickStarts
-name: rosa-edit-cluster-autoscaling
+name: rosa-osd-edit-cluster-autoscaling
 tags:
   - kind: bundle
     value: openshift

--- a/docs/quickstarts/rosa-osd-edit-cluster-autoscaling/rosa-osd-edit-cluster-autoscaling.yml
+++ b/docs/quickstarts/rosa-osd-edit-cluster-autoscaling/rosa-osd-edit-cluster-autoscaling.yml
@@ -1,25 +1,27 @@
 
 metadata:
-  name: rosa-edit-cluster-autoscaling
+  name: rosa-osd-edit-cluster-autoscaling
   instructional: true
 spec:
-  displayName: Configure autoscaling for your ROSA cluster
+  displayName: Configuring autoscaling for your managed OpenShift cluster
   durationMinutes: 10
   type:
     text: Quick start
     color: green
   icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
   prerequisites:
-    - You must have access to a ROSA cluster.
+    - You must have access to a managed OpenShift cluster.
     - You must be a cluster owner or Organization Administrator for the cluster.
   description: |-
-    Enable and edit autoscaling for your ROSA cluster.
+    Enable and edit autoscaling for your managed OpenShift cluster.
   introduction: |-
-    Using OpenShift Cluster Manager, you can enable and customize cluster autoscaling for your Red Hat OpenShift on Amazon Web Services (ROSA) cluster.
+    Using OpenShift Cluster Manager, you can enable and customize cluster autoscaling for your Red Hat OpenShift on Amazon Web Services (ROSA) or Red Hat OpenShift Dedicated (OSD) cluster.
 
-    The cluster autoscaler adjusts the size of a ROSA cluster to meet your current deployment needs, but does not increase the cluster resources beyond the limits that you specify. It also increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs.
+    The cluster autoscaler adjusts the size of a managed OpenShift cluster to meet your current deployment needs, but does not increase the cluster resources beyond the limits that you specify. It also increases the size of the cluster when there are pods that fail to schedule on any of the current worker nodes due to insufficient resources or when another node is necessary to meet deployment needs.
 
-    In this quick start, you'll learn how to enable and edit cluster autoscaling for your ROSA cluster.
+    In this quick start, you'll learn how to enable and edit cluster autoscaling for your ROSA or OSD cluster.
+   
+    [In this quick start, when we refer to ROSA, we are referring to both ROSA classic architecture and ROSA with HCP, and when we refer to OSD, we are referring to both OSD on GCP and OSD on AWS.]{{admonition note}}
 
   tasks:
     - title: Enable cluster autoscaling
@@ -30,7 +32,7 @@ spec:
         1. Click your cluster's name.
         1. Click the **Machine pools** tab.
         1. Click the options icon (⋮), then click **Edit**.
-        1. In the **Edit machine pool** window, check the **Enable autoscaling** box.
+        1. In the **Edit machine pool** window, check the **Enable autoscaling** box. [The **Enable autoscaling** option is only available for OSD clusters if you have the `capability.cluster.autoscale_clusters` subscription. For more information, contact your sales representative or Red Hat support.]{{admonition note}}
         1. Click **Save**.
 
       # optional - the task's Check your work module
@@ -49,7 +51,7 @@ spec:
 
         1. On the **Machine pools** tab of your cluster, click **Edit cluster autoscaling**.
         1. If not already active, click the **Autoscale cluster** toggle. If you've already enabled it in the previous step, this should be active already.
-        1. All autoscaling options are filled in with defaults. [Learn more about what each option does.](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-cluster-autoscaling#rosa-cluster-autoscale-settings_rosa-cluster-autoscaling)
+        1. All autoscaling options are filled in with defaults. Learn more about what each option does for [ROSA](https://docs.redhat.com/en/documentation/red_hat_openshift_service_on_aws/4/html/cluster_administration/rosa-cluster-autoscaling#rosa-cluster-autoscale-settings_rosa-cluster-autoscaling) and [OSD](https://docs.redhat.com/en/documentation/openshift_dedicated/4/html/cluster_administration/osd-cluster-autoscaling#rosa-cluster-autoscale-settings_osd-cluster-autoscaling).
 
             a. If you changed something and didn't like the change or changed something by accident, you can click **Revert all to defaults** to change your settings back.
 
@@ -67,6 +69,6 @@ spec:
   conclusion: |-
         Congratulations, you've configured cluster autoscaling!
 
-        After completing this quick start, you've learned how to enable and edit cluster autoscaling. If you create other machine pools, you can use this quick start to configure cluster autoscaling to those as well.
+        After completing this quick start, you've learned how to enable and edit cluster autoscaling. If you create other machine pools, you can use this quick start to configure cluster autoscaling for those as well.
 
   # you can link to the next quick start(s) here


### PR DESCRIPTION
This PR is to update the ROSA cluster autoscaling quick start so it is also applicable to OSD by

- Ensuring the quick start is also relevant for users of OSD clusters
- Updating the title, file title, and metadata accordingly

Issues:

OSDOCS:
https://issues.redhat.com/browse/OSDOCS-13604
