### PR TITLE
Created new card for service accounts doc link

### DIFF
--- a/docs/quickstarts/rbac-service-accounts/metadata.yaml
+++ b/docs/quickstarts/rbac-service-accounts/metadata.yaml
@@ -1,0 +1,19 @@
+kind: QuickStarts
+name: rbac-service-accounts
+tags:
+  - kind: bundle
+    value: iam
+  - kind: bundle
+    value: settings
+  - kind: content
+    value: documentation
+  - kind: product-families
+    value: settings 
+  - kind: product-families
+    value: iam
+  - kind: product-families
+    value: security
+  - kind: use-case
+    value: identity-and-access
+  - kind: use-case
+    value: system-configuration

--- a/docs/quickstarts/rbac-service-accounts/rbac-service-accounts.yml
+++ b/docs/quickstarts/rbac-service-accounts/rbac-service-accounts.yml
@@ -1,0 +1,13 @@
+metadata:
+  name: rbac-service-accounts
+  externalDocumentation: true
+spec:
+  displayName: Creating and managing service accounts
+  description: Create a service account to access console services.
+  type:
+    text: Documentation
+    color: orange
+  link:
+    text: View documentation
+    href: https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/creating_and_managing_service_accounts/index
+  prerequisites: []


### PR DESCRIPTION
Added new card for Creating and managing service accounts doc.

https://issues.redhat.com/browse/HCCDOC-3693 

The docs team confirmed the text and tags in a meeting this week (details in Jira). CC: @florkbr @ryelo 