### PR TITLE
OSDOCS-13607:Amended ROSA app ingress quickstart to also refer to OSD.

### DIFF
--- a/docs/quickstarts/rosa-osd-edit-app-ingress/metadata.yml
+++ b/docs/quickstarts/rosa-osd-edit-app-ingress/metadata.yml
@@ -1,5 +1,5 @@
 kind: QuickStarts
-name: rosa-edit-app-ingress
+name: rosa-osd-edit-app-ingress
 tags:
   - kind: bundle
     value: openshift

--- a/docs/quickstarts/rosa-osd-edit-app-ingress/rosa-osd-edit-app-ingress.yml
+++ b/docs/quickstarts/rosa-osd-edit-app-ingress/rosa-osd-edit-app-ingress.yml
@@ -1,22 +1,24 @@
 
 metadata:
-  name: rosa-edit-app-ingress
+  name: rosa-osd-edit-app-ingress
   instructional: true
 spec:
-  displayName: Edit your ROSA cluster's application ingress
+  displayName: Editing your managed OpenShift cluster's application ingress
   durationMinutes: 5
   type:
     text: Quick start
     color: green
   icon: data:image/svg+xml;base64,PCEtLSBHZW5lcmF0ZWQgYnkgSWNvTW9vbi5pbyAtLT4KPHN2ZyB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjUxMiIgaGVpZ2h0PSI1MTIiIHZpZXdCb3g9IjAgMCA1MTIgNTEyIj4KPHRpdGxlPjwvdGl0bGU+CjxnIGlkPSJpY29tb29uLWlnbm9yZSI+CjwvZz4KPHBhdGggZD0iTTQ0OCA2NHY0MTZoLTMzNmMtMjYuNTEzIDAtNDgtMjEuNDktNDgtNDhzMjEuNDg3LTQ4IDQ4LTQ4aDMwNHYtMzg0aC0zMjBjLTM1LjE5OSAwLTY0IDI4LjgtNjQgNjR2Mzg0YzAgMzUuMiAyOC44MDEgNjQgNjQgNjRoMzg0di00NDhoLTMyeiI+PC9wYXRoPgo8cGF0aCBkPSJNMTEyLjAyOCA0MTZ2MGMtMC4wMDkgMC4wMDEtMC4wMTkgMC0wLjAyOCAwLTguODM2IDAtMTYgNy4xNjMtMTYgMTZzNy4xNjQgMTYgMTYgMTZjMC4wMDkgMCAwLjAxOS0wLjAwMSAwLjAyOC0wLjAwMXYwLjAwMWgzMDMuOTQ1di0zMmgtMzAzLjk0NXoiPjwvcGF0aD4KPC9zdmc+Cg==
   prerequisites:
-    - You must have a ROSA cluster.
+    - You must have a ROSA or OSD cluster.
     - You must be a cluster owner, cluster editor, or Organization Administrator for the cluster.
 
   description: |-
-    Edit the application ingress of your ROSA cluster after creation.
+    Edit the application ingress of your managed OpenShift cluster after creation.
   introduction: |-
-    Using OpenShift Cluster Manager, you can edit the application ingress of your ROSA clusters. In this quick start, you'll learn how to edit your ROSA cluster's application ingress.
+    Using OpenShift Cluster Manager, you can edit the application ingress of your Red Hat OpenShift Service on Amazon Web Services (ROSA) or Red Hat OpenShift Dedicated (OSD) clusters. In this quick start, you'll learn how to edit your ROSA or OSD cluster's application ingress.
+
+    [In this quick start, when we refer to ROSA, we are referring to both ROSA classic architecture and ROSA with HCP, and when we refer to OSD, we are referring to both OSD on GCP and OSD on AWS.]{{admonition note}}
 
   tasks:
     - title: Edit application ingress for your cluster
@@ -24,17 +26,15 @@ spec:
         To edit your cluster's application ingress:
 
         1. Go to **Cluster List**.
-        1. Click your cluster's name to view cluster details.
+        1. Click your cluster's name to view the cluster details.
         1. Click the **Networking** tab.
-        1. In the Application Ingress section, click the **Edit application ingress** button.
+        1. In the **Application Ingress** section, click the **Edit application ingress** button.
 
             a. You can change the Default application router if needed.
 
             b. Click the checkbox if you want to make your router private.
 
         1. Click **Save** to finalize your changes.
-
-        Your cluster should now have the newly updated application ingress..
 
   # optional - the task's Check your work module
       review:
@@ -48,5 +48,5 @@ spec:
   conclusion: |-
         Congratulations, you've edited your cluster's application ingress!
 
-        You can edit your application ingress as often as needed.
+        You can edit your cluster's application ingress as often as needed.
   # you can link to the next quick start(s) here


### PR DESCRIPTION
This PR is to update the ROSA application ingress quick start so it is also applicable to OSD by

- Ensuring the quick start is also relevant for users of OSD clusters
- Updating the title, file title, and metadata accordingly

Issues:

OSDOCS:
https://issues.redhat.com/browse/OSDOCS-13607