### PR TITLE
HCCDOC-3713 LR for integrating inventory with AAP

### DIFF
--- a/docs/quickstarts/insights-integrate-inventory-aap/insights-integrate-inventory-aap.yml
+++ b/docs/quickstarts/insights-integrate-inventory-aap/insights-integrate-inventory-aap.yml
@@ -10,7 +10,7 @@ spec:
     color: orange
   displayName: Integrating Insights as an inventory source in Ansible Automation Platform
   icon: ~
-  description: Configuring Insights as an inventory source in AAP to pull system data into automation workflows.
+  description: Configure Insights to pull system data into automation workflows.
   link:
     href: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_execution/index#proc-controller-inv-source-insights
     text: View documentation

--- a/docs/quickstarts/insights-integrate-inventory-aap/insights-integrate-inventory-aap.yml
+++ b/docs/quickstarts/insights-integrate-inventory-aap/insights-integrate-inventory-aap.yml
@@ -1,0 +1,16 @@
+apiVersion: console.openshift.io/v1
+kind: QuickStarts
+metadata:
+  name: insights-integrate-inventory-aap
+  externalDocumentation: true
+spec:
+  version: 0.1
+  type:
+    text: Documentation
+    color: orange
+  displayName: Integrating Insights as an inventory source in Ansible Automation Platform
+  icon: ~
+  description: Configuring Insights as an inventory source in AAP to pull system data into automation workflows.
+  link:
+    href: https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html-single/using_automation_execution/index#proc-controller-inv-source-insights
+    text: View documentation

--- a/docs/quickstarts/insights-integrate-inventory-aap/metadata.yml
+++ b/docs/quickstarts/insights-integrate-inventory-aap/metadata.yml
@@ -1,0 +1,17 @@
+kind: QuickStarts
+name: insights-integrate-inventory-aap
+tags:
+- kind: bundle
+  value: insights
+- kind: bundle
+  value: ansible
+- kind: content
+  value: documentation
+- kind: product-families
+  value: rhel
+- kind: use-case
+  value: automation
+- kind: use-case
+  value: system-configuration
+- kind: use-case
+  value: infrastructure


### PR DESCRIPTION
Learning Resource card to docs to integrate inventory with Ansible Automation Platform

## Summary by Sourcery

Documentation:
- Add metadata and manifest files for the insights-integrate-inventory-aap QuickStart
@florkbr @ryelo