### PR TITLE
Fix nextquickstart link

### DIFF
--- a/docs/quickstarts/insights-inventory-workspace/insights-inventory-workspace.yaml
+++ b/docs/quickstarts/insights-inventory-workspace/insights-inventory-workspace.yaml
@@ -131,7 +131,7 @@ spec:
       
       You can use workspaces to streamline access control for your inventory and restrict access to resources.
       
-      We'd love your help developing workspaces! To join a user research session or provide feedback about your experience, click the **Feedback** button on the right side of the console to get in touch. 
+      We'd love your help developing workspaces! To join a user research session or provide feedback about your experience, click the **Feedback** button on the right side of the console. 
       
       From there, you can also [open a support case](https://access.redhat.com/support) for additional assistance.
 
@@ -140,6 +140,7 @@ spec:
       - Learn more about workspaces in [Viewing and managing system inventory](https://docs.redhat.com/en/documentation/red_hat_insights/1-latest/html/viewing_and_managing_system_inventory/index). 
       
       **Next steps**:
-      - Configure user access for your workspaces using this quick start:
+      - Configure user access for your workspaces:
       
-  nextQuickStart: [insights-inventory-workspace-rbac]
+  nextQuickStart:
+    - insights-inventory-workspace-rbac


### PR DESCRIPTION
In the current YAML, the nextQuickStart link doesn't open the User Access quickstart.
This fix should allow that quick start to open at the end of the Create workspaces quickstart.

@florkbr @tahmidefaz @ryelo and team, can you please verify that this is the right syntax to open a new quickstart?
I tested it in the [React tool](https://quickstarts-content-preview.surge.sh/) - the previous code worked there too, but I have used the YAML markup from the quickstarts template.

Docs Jira: https://issues.redhat.com/browse/HCCDOC-3907
RHCLOUD Jira: https://issues.redhat.com/browse/RHCLOUD-21485 

Thank you!

<img width="1025" height="692" alt="Screenshot 2025-07-22 at 12 59 16" src="https://github.com/user-attachments/assets/7b40d513-d2b6-4807-87d8-031a99491046" />

## Summary by Sourcery

Update the insights-inventory-workspace quickstart to correct the nextQuickStart link for user access configuration and streamline the feedback prompt wording.

Bug Fixes:
- Fix nextQuickStart YAML syntax to properly open the User Access quickstart

Documentation:
- Remove redundant wording from the feedback prompt