### PR TITLE
Update to latest UBI9 image and Go 1.24.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.23.6-1.1744600118 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.6-1756993846 AS builder
 WORKDIR $GOPATH/src/mypackage/myapp/
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -20,7 +20,7 @@ RUN CGO_ENABLED=0 go build -buildvcs=false -o /go/bin/quickstarts
 RUN CGO_ENABLED=0 go build -o /go/bin/quickstarts-migrate cmd/migrate/migrate.go
 
  
-FROM registry.access.redhat.com/ubi8-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 COPY --from=builder /go/bin/quickstarts /usr/bin
 COPY --from=builder /go/bin/quickstarts-migrate /usr/bin

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/RedHatInsights/quickstarts
 
-go 1.23.0
+go 1.24.6
 
-toolchain go1.23.6
+toolchain go1.24.6
 
 require (
 	github.com/getkin/kin-openapi v0.76.0


### PR DESCRIPTION
## Summary by Sourcery

Update Docker base images to UBI9 and bump Go version to 1.24.6 across the build configuration.

Enhancements:
- Use registry.access.redhat.com/ubi9/go-toolset:1.24.6 for the builder stage
- Switch the runtime image to registry.access.redhat.com/ubi9-minimal
- Update go.mod to specify Go 1.24.6 and toolchain go1.24.6