### PR TITLE
feat: add endpoint for fuzzy search

### DIFF
--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -33,6 +33,11 @@ func Init() {
 
 	DB, err = gorm.Open(dia, &gorm.Config{})
 
+	// Enable fuzzystrmatch extension for Levenshtein distance fuzzy search
+	if !cfg.Test { // Only enable for non-test environments (PostgreSQL)
+		DB.Exec("CREATE EXTENSION IF NOT EXISTS fuzzystrmatch;")
+	}
+
 	if !DB.Migrator().HasTable(&models.Quickstart{}) {
 		DB.Migrator().CreateTable(&models.Quickstart{})
 	}


### PR DESCRIPTION
[RHCLOUD-40633](https://issues.redhat.com/browse/RHCLOUD-40633)

## Summary by Sourcery

Add fuzzy search endpoint for quickstarts enabling typo-tolerant lookup on display names.

New Features:
- Introduce /fuzzy-search endpoint to perform fuzzy matching on quickstart displayName
- Define FuzzySearchResult type and findQuickstartsByFuzzySearch function using Levenshtein distance

Enhancements:
- Enable PostgreSQL fuzzystrmatch extension on database initialization
- Update test fixtures to include spec.displayName and related fields in quickstart content

Tests:
- Add comprehensive TestFuzzySearch suite covering missing parameters, exact and fuzzy matches, pagination, and various search scenarios