### PR TITLE
Add Learning resource card for IDP doc

### DIFF
--- a/docs/rbac-configuring-idp/metadata.yaml
+++ b/docs/rbac-configuring-idp/metadata.yaml
@@ -1,0 +1,17 @@
+kind: QuickStarts
+name: rbac-configuring-idp
+tags:
+  - kind: bundle
+    value: iam
+  - kind: bundle
+    value: settings
+  - kind: content
+    value: documentation
+  - kind: product-families
+    value: settings 
+  - kind: product-families
+    value: iam
+  - kind: use-case
+    value: identity-and-access
+  - kind: use-case
+    value: security

--- a/docs/rbac-configuring-idp/rbac-configuring-idp.yml
+++ b/docs/rbac-configuring-idp/rbac-configuring-idp.yml
@@ -1,0 +1,13 @@
+metadata:
+  name: rbac-configuring-idp
+  externalDocumentation: true
+spec:
+  displayName: Configuring identity provider integration
+  description: Configure IdP integration to authorize your users.
+  type:
+    text: Documentation
+    color: orange
+  link:
+    text: View documentation
+    href: https://docs.redhat.com/en/documentation/red_hat_hybrid_cloud_console/1-latest/html/configuring_identity_provider_integration/index
+  prerequisites: []


### PR DESCRIPTION
Please add this new (documentation type) Learning Resources card to HCC - Configuring identity provider integration

RHCLOUD issue: https://issues.redhat.com/browse/RHCLOUD-42417
Docs issue: https://issues.redhat.com/browse/HCCDOC-4352

## Summary by Sourcery

Add a new learning resource QuickStarts card to HCC for the identity provider integration documentation

New Features:
- Add new QuickStarts learning resource card for configuring identity provider integration

Documentation:
- Include metadata tags and specification file linking to the external identity provider integration documentation