### PR TITLE
feat(docker): add git CLI to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,10 @@ RUN CGO_ENABLED=0 go build -o /go/bin/quickstarts-migrate cmd/migrate/migrate.go
  
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
+RUN microdnf install -y git-core && \
+    microdnf clean all && \
+    git --version
+
 COPY --from=builder /go/bin/quickstarts /usr/bin
 COPY --from=builder /go/bin/quickstarts-migrate /usr/bin
 COPY --from=builder /src/mypackage/myapp/spec/openapi.json /var/tmp


### PR DESCRIPTION
## Summary
- Installs `git-core` in the `ubi9-minimal` runtime stage to enable git operations from the quickstarts API
- Uses `git-core` (not full `git`) for minimal image footprint — avoids pulling in perl/python dependencies
- Verifies installation at build time via `git --version`

RHCLOUD-39698

## Test plan
- [ ] Docker image builds successfully with `git-core` installed
- [ ] `git --version` prints during build (verified at build time)
- [ ] `git` binary is accessible at runtime as user 1001
- [ ] Image size increase is minimal (~15-20 MB for `git-core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)