### PR TITLE
feat(git): add git proxy endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,5 @@ GIT_REPO_URL=https://github.com/RedHatInsights/quickstarts.git
 GIT_AUTH_TOKEN=
 GIT_DEFAULT_BRANCH=main
 GIT_TEMP_DIR=
+GIT_USER_NAME=nachobot
+GIT_USER_EMAIL=nachobot@redhat.com

--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,9 @@ PGSQL_PORT=
 PGSQL_DATABASE=
 LOG_LEVEL=WARN
 FUZZY_SEARCH_DISTANCE_THRESHOLD=3
+
+# Git proxy configuration (for POST /git/pull-request)
+GIT_REPO_URL=https://github.com/RedHatInsights/quickstarts.git
+GIT_AUTH_TOKEN=
+GIT_DEFAULT_BRANCH=main
+GIT_TEMP_DIR=

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,8 @@ type QuickstartsConfig struct {
 	GitAuthToken           string // Personal access token for git push and PR creation
 	GitDefaultBranch       string // Default branch of the target repo (e.g. main)
 	GitTempDir             string // Temp directory for git clone operations
+	GitUserName            string // Git committer name (default: nachobot)
+	GitUserEmail           string // Git committer email (default: nachobot@redhat.com)
 }
 
 var config *QuickstartsConfig
@@ -70,6 +72,14 @@ func Init() {
 	config.GitTempDir = os.Getenv("GIT_TEMP_DIR")
 	if config.GitTempDir == "" {
 		config.GitTempDir = os.TempDir()
+	}
+	config.GitUserName = os.Getenv("GIT_USER_NAME")
+	if config.GitUserName == "" {
+		config.GitUserName = "nachobot"
+	}
+	config.GitUserEmail = os.Getenv("GIT_USER_EMAIL")
+	if config.GitUserEmail == "" {
+		config.GitUserEmail = "nachobot@redhat.com"
 	}
 
 	if clowder.IsClowderEnabled() {

--- a/config/config.go
+++ b/config/config.go
@@ -22,6 +22,10 @@ type QuickstartsConfig struct {
 	DbSSLRootCert          string
 	LogLevel               string
 	MaxFuzzySearchDistance int // Max Levenshtein distance for fuzzy search (typo tolerance)
+	GitRepoURL             string // Target repository URL for git proxy (e.g. https://github.com/org/repo.git)
+	GitAuthToken           string // Personal access token for git push and PR creation
+	GitDefaultBranch       string // Default branch of the target repo (e.g. main)
+	GitTempDir             string // Temp directory for git clone operations
 }
 
 var config *QuickstartsConfig
@@ -54,6 +58,18 @@ func Init() {
 		} else {
 			config.MaxFuzzySearchDistance = threshold
 		}
+	}
+
+	// Git proxy configuration
+	config.GitRepoURL = os.Getenv("GIT_REPO_URL")
+	config.GitAuthToken = os.Getenv("GIT_AUTH_TOKEN")
+	config.GitDefaultBranch = os.Getenv("GIT_DEFAULT_BRANCH")
+	if config.GitDefaultBranch == "" {
+		config.GitDefaultBranch = "main"
+	}
+	config.GitTempDir = os.Getenv("GIT_TEMP_DIR")
+	if config.GitTempDir == "" {
+		config.GitTempDir = os.TempDir()
 	}
 
 	if clowder.IsClowderEnabled() {

--- a/pkg/routes/git_handlers.go
+++ b/pkg/routes/git_handlers.go
@@ -1,0 +1,46 @@
+package routes
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/RedHatInsights/quickstarts/pkg/generated"
+	"github.com/RedHatInsights/quickstarts/pkg/utils"
+	"github.com/sirupsen/logrus"
+)
+
+// PostGitPullRequest handles POST /git/pull-request
+func (s *ServerAdapter) PostGitPullRequest(w http.ResponseWriter, r *http.Request) {
+	var reqBody generated.GitPullRequestRequest
+	if err := json.NewDecoder(r.Body).Decode(&reqBody); err != nil {
+		utils.ErrorResponse(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+
+	// Validate required fields
+	if reqBody.Title == "" {
+		utils.ErrorResponse(w, http.StatusBadRequest, "title is required")
+		return
+	}
+
+	// Validate files
+	if err := s.gitService.ValidateFiles(reqBody.Files); err != nil {
+		utils.ErrorResponse(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	// Create the pull request
+	result, err := s.gitService.CreatePullRequest(reqBody)
+	if err != nil {
+		logrus.Errorf("git proxy error: %v", err)
+		utils.ErrorResponse(w, http.StatusInternalServerError, "failed to create pull request: "+err.Error())
+		return
+	}
+
+	resp := generated.GitPullRequestResponse{
+		PrUrl:  &result.PRUrl,
+		Branch: &result.Branch,
+	}
+
+	utils.DataResponse(w, http.StatusCreated, resp)
+}

--- a/pkg/routes/git_handlers_test.go
+++ b/pkg/routes/git_handlers_test.go
@@ -1,0 +1,120 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostGitPullRequest_InvalidJSON(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "invalid request body")
+}
+
+func TestPostGitPullRequest_MissingTitle(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"files": [{"path": "test.yaml", "content": "name: test"}]}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "title is required")
+}
+
+func TestPostGitPullRequest_EmptyFiles(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"title": "Test PR", "files": []}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "at least one file is required")
+}
+
+func TestPostGitPullRequest_InvalidFilePath(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"title": "Test PR", "files": [{"path": "../etc/passwd", "content": "content"}]}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "path traversal not allowed")
+}
+
+func TestPostGitPullRequest_InvalidFileExtension(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"title": "Test PR", "files": [{"path": "test.exe", "content": "content"}]}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unsupported file extension")
+}
+
+func TestPostGitPullRequest_MissingGitConfig(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"title": "Test PR", "files": [{"path": "quickstarts/test.yaml", "content": "name: test"}]}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	// Should fail with 500 because GIT_REPO_URL is not configured
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "GIT_REPO_URL is not configured")
+}
+
+func TestPostGitPullRequest_EmptyBody(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(""))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostGitPullRequest_EmptyFileContent(t *testing.T) {
+	adapter := NewServerAdapter()
+
+	body := `{"title": "Test PR", "files": [{"path": "test.yaml", "content": "  "}]}`
+	req := httptest.NewRequest("POST", "/git/pull-request", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	adapter.PostGitPullRequest(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "file content cannot be empty")
+}

--- a/pkg/routes/server_adapter.go
+++ b/pkg/routes/server_adapter.go
@@ -16,6 +16,7 @@ type ServerAdapter struct {
 	helpTopicService  *services.HelpTopicService
 	favoriteService   *services.FavoriteService
 	progressService   *services.ProgressService
+	gitService        *services.GitService
 }
 
 // NewServerAdapter creates a new server adapter with service dependencies
@@ -25,5 +26,6 @@ func NewServerAdapter() *ServerAdapter {
 		helpTopicService:  services.NewHelpTopicService(),
 		favoriteService:   services.NewFavoriteService(),
 		progressService:   services.NewProgressService(),
+		gitService:        services.NewGitService(),
 	}
 }

--- a/pkg/services/git_service.go
+++ b/pkg/services/git_service.go
@@ -1,15 +1,21 @@
 package services
 
 import (
+	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/RedHatInsights/quickstarts/config"
 	"github.com/RedHatInsights/quickstarts/pkg/generated"
@@ -61,14 +67,16 @@ func (s *GitService) CreatePullRequest(req generated.GitPullRequestRequest) (*Pu
 
 	repoDir := filepath.Join(tmpDir, "repo")
 
-	// Build authenticated clone URL
-	cloneURL, err := buildAuthURL(cfg.GitRepoURL, cfg.GitAuthToken)
+	// Create a GIT_ASKPASS helper script to supply credentials without
+	// embedding tokens in the clone URL (avoids exposure via process listing)
+	askpassScript, err := createAskpassScript(cfg.GitAuthToken, tmpDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build authenticated URL: %w", err)
+		return nil, fmt.Errorf("failed to create askpass helper: %w", err)
 	}
+	defer os.Remove(askpassScript)
 
 	// Clone the repository (shallow clone for speed)
-	if err := runGit(tmpDir, "clone", "--depth", "1", "--branch", cfg.GitDefaultBranch, cloneURL, "repo"); err != nil {
+	if err := runGitWithAskpass(tmpDir, askpassScript, "clone", "--depth", "1", "--branch", cfg.GitDefaultBranch, cfg.GitRepoURL, "repo"); err != nil {
 		return nil, fmt.Errorf("failed to clone repository: %w", err)
 	}
 
@@ -96,11 +104,11 @@ func (s *GitService) CreatePullRequest(req generated.GitPullRequestRequest) (*Pu
 		return nil, fmt.Errorf("failed to stage files: %w", err)
 	}
 
-	// Configure git user for the commit
-	if err := runGit(repoDir, "config", "user.email", "nachobot@redhat.com"); err != nil {
+	// Configure git user for the commit (configurable via env vars)
+	if err := runGit(repoDir, "config", "user.email", cfg.GitUserEmail); err != nil {
 		return nil, fmt.Errorf("failed to configure git email: %w", err)
 	}
-	if err := runGit(repoDir, "config", "user.name", "nachobot"); err != nil {
+	if err := runGit(repoDir, "config", "user.name", cfg.GitUserName); err != nil {
 		return nil, fmt.Errorf("failed to configure git name: %w", err)
 	}
 
@@ -113,12 +121,12 @@ func (s *GitService) CreatePullRequest(req generated.GitPullRequestRequest) (*Pu
 		return nil, fmt.Errorf("failed to commit: %w", err)
 	}
 
-	// Push the branch
-	if err := runGit(repoDir, "push", "origin", branch); err != nil {
+	// Push the branch (using askpass for auth)
+	if err := runGitWithAskpass(repoDir, askpassScript, "push", "origin", branch); err != nil {
 		return nil, fmt.Errorf("failed to push branch: %w", err)
 	}
 
-	// Create the pull request using the GitHub API via git
+	// Create the pull request using the GitHub REST API
 	prURL, err := createGitHubPR(cfg, branch, req.Title, req.Description)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create pull request: %w", err)
@@ -198,40 +206,56 @@ func randomHex(n int) (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// buildAuthURL injects a token into an HTTPS git URL for authentication
-func buildAuthURL(repoURL, token string) (string, error) {
-	u, err := url.Parse(repoURL)
+// createAskpassScript creates a temporary script that supplies the token
+// via GIT_ASKPASS, keeping credentials out of the process argument list.
+func createAskpassScript(token, tmpDir string) (string, error) {
+	script := fmt.Sprintf("#!/bin/sh\necho '%s'\n", token)
+	f, err := os.CreateTemp(tmpDir, "git-askpass-*.sh")
 	if err != nil {
-		return "", fmt.Errorf("invalid repository URL: %w", err)
+		return "", err
 	}
-
-	if u.Scheme != "https" {
-		return "", fmt.Errorf("only HTTPS repository URLs are supported")
+	if _, err := f.WriteString(script); err != nil {
+		f.Close()
+		os.Remove(f.Name())
+		return "", err
 	}
-
-	u.User = url.UserPassword("x-access-token", token)
-	return u.String(), nil
+	f.Close()
+	if err := os.Chmod(f.Name(), 0700); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 // runGit executes a git command in the given directory
 func runGit(dir string, args ...string) error {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir
-	// Mask credentials from logs
-	safeArgs := make([]string, len(args))
-	copy(safeArgs, args)
-	for i, arg := range safeArgs {
-		if strings.Contains(arg, "x-access-token") {
-			safeArgs[i] = "<REDACTED_URL>"
-		}
-	}
-	logrus.Debugf("git %s (in %s)", strings.Join(safeArgs, " "), dir)
+	logrus.Debugf("git %s (in %s)", strings.Join(args, " "), dir)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		// Redact any tokens from the error output
 		sanitized := redactToken(string(output))
-		return fmt.Errorf("git %s failed: %s: %s", safeArgs[0], err, sanitized)
+		return fmt.Errorf("git %s failed: %s: %s", args[0], err, sanitized)
+	}
+	return nil
+}
+
+// runGitWithAskpass executes a git command with GIT_ASKPASS set for auth.
+// This keeps tokens out of the process argument list (visible via ps/top).
+func runGitWithAskpass(dir, askpassScript string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GIT_ASKPASS=%s", askpassScript),
+		"GIT_TERMINAL_PROMPT=0",
+	)
+	logrus.Debugf("git %s (in %s)", strings.Join(args, " "), dir)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		sanitized := redactToken(string(output))
+		return fmt.Errorf("git %s failed: %s: %s", args[0], err, sanitized)
 	}
 	return nil
 }
@@ -243,9 +267,22 @@ func redactToken(s string) string {
 	return re.ReplaceAllString(s, "${1}***@")
 }
 
-// createGitHubPR creates a pull request using the GitHub REST API
+// ghPullRequestRequest is the JSON body for creating a GitHub PR
+type ghPullRequestRequest struct {
+	Title string `json:"title"`
+	Head  string `json:"head"`
+	Base  string `json:"base"`
+	Body  string `json:"body"`
+}
+
+// ghPullRequestResponse is the relevant part of the GitHub PR response
+type ghPullRequestResponse struct {
+	HTMLURL string `json:"html_url"`
+	Message string `json:"message,omitempty"`
+}
+
+// createGitHubPR creates a pull request using Go's net/http client
 func createGitHubPR(cfg *config.QuickstartsConfig, branch, title string, description *string) (string, error) {
-	// Parse owner/repo from the repo URL
 	owner, repo, err := parseGitHubRepo(cfg.GitRepoURL)
 	if err != nil {
 		return "", err
@@ -256,33 +293,56 @@ func createGitHubPR(cfg *config.QuickstartsConfig, branch, title string, descrip
 		body = *description
 	}
 
-	// Use curl to create the PR via GitHub API
+	reqBody := ghPullRequestRequest{
+		Title: title,
+		Head:  branch,
+		Base:  cfg.GitDefaultBranch,
+		Body:  body,
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal PR request: %w", err)
+	}
+
 	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls", owner, repo)
-	jsonBody := fmt.Sprintf(
-		`{"title":%q,"head":%q,"base":%q,"body":%q}`,
-		title, branch, cfg.GitDefaultBranch, body,
-	)
 
-	cmd := exec.Command("curl", "-s", "-X", "POST",
-		"-H", "Accept: application/vnd.github+json",
-		"-H", fmt.Sprintf("Authorization: Bearer %s", cfg.GitAuthToken),
-		"-H", "Content-Type: application/json",
-		"-d", jsonBody,
-		apiURL,
-	)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-	output, err := cmd.CombinedOutput()
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Accept", "application/vnd.github+json")
+	httpReq.Header.Set("Authorization", fmt.Sprintf("Bearer %s", cfg.GitAuthToken))
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
 		return "", fmt.Errorf("GitHub API request failed: %w", err)
 	}
+	defer resp.Body.Close()
 
-	// Parse the response to extract the PR URL
-	prURL, err := extractPRUrl(output)
+	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse GitHub API response: %w: %s", err, redactToken(string(output)))
+		return "", fmt.Errorf("failed to read GitHub API response: %w", err)
 	}
 
-	return prURL, nil
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("GitHub API returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var prResp ghPullRequestResponse
+	if err := json.Unmarshal(respBody, &prResp); err != nil {
+		return "", fmt.Errorf("failed to parse GitHub API response: %w", err)
+	}
+
+	if prResp.HTMLURL == "" {
+		return "", fmt.Errorf("GitHub API response missing html_url: %s", string(respBody))
+	}
+
+	return prResp.HTMLURL, nil
 }
 
 // parseGitHubRepo extracts owner and repo name from a GitHub URL
@@ -301,32 +361,4 @@ func parseGitHubRepo(repoURL string) (string, string, error) {
 	}
 
 	return parts[0], parts[1], nil
-}
-
-// extractPRUrl parses the GitHub API JSON response to extract the html_url
-func extractPRUrl(response []byte) (string, error) {
-	// Simple JSON parsing without importing encoding/json to avoid
-	// a dependency on the exact response structure
-	// Look for "html_url": "..." in the response
-	s := string(response)
-
-	// Check for error response
-	if strings.Contains(s, `"message"`) && !strings.Contains(s, `"html_url"`) {
-		return "", fmt.Errorf("GitHub API error: %s", s)
-	}
-
-	// Find the html_url field (first occurrence is the PR URL)
-	marker := `"html_url":"`
-	idx := strings.Index(s, marker)
-	if idx == -1 {
-		return "", fmt.Errorf("html_url not found in response")
-	}
-
-	start := idx + len(marker)
-	end := strings.Index(s[start:], `"`)
-	if end == -1 {
-		return "", fmt.Errorf("malformed html_url in response")
-	}
-
-	return s[start : start+end], nil
 }

--- a/pkg/services/git_service.go
+++ b/pkg/services/git_service.go
@@ -1,0 +1,332 @@
+package services
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/RedHatInsights/quickstarts/config"
+	"github.com/RedHatInsights/quickstarts/pkg/generated"
+	"github.com/sirupsen/logrus"
+)
+
+// GitService handles git operations for the git proxy endpoint
+type GitService struct{}
+
+// NewGitService creates a new GitService
+func NewGitService() *GitService {
+	return &GitService{}
+}
+
+// PullRequestResult holds the result of a successful PR creation
+type PullRequestResult struct {
+	PRUrl  string
+	Branch string
+}
+
+// CreatePullRequest performs the full git workflow:
+// clone → branch → write files → commit → push → create PR
+func (s *GitService) CreatePullRequest(req generated.GitPullRequestRequest) (*PullRequestResult, error) {
+	cfg := config.Get()
+
+	if cfg.GitRepoURL == "" {
+		return nil, fmt.Errorf("GIT_REPO_URL is not configured")
+	}
+	if cfg.GitAuthToken == "" {
+		return nil, fmt.Errorf("GIT_AUTH_TOKEN is not configured")
+	}
+
+	// Generate a unique branch name
+	branch, err := generateBranchName(req.Title)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate branch name: %w", err)
+	}
+
+	// Create a temp directory for the clone
+	tmpDir, err := os.MkdirTemp(cfg.GitTempDir, "quickstarts-git-*")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer func() {
+		if removeErr := os.RemoveAll(tmpDir); removeErr != nil {
+			logrus.Warnf("failed to clean up temp directory %s: %v", tmpDir, removeErr)
+		}
+	}()
+
+	repoDir := filepath.Join(tmpDir, "repo")
+
+	// Build authenticated clone URL
+	cloneURL, err := buildAuthURL(cfg.GitRepoURL, cfg.GitAuthToken)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build authenticated URL: %w", err)
+	}
+
+	// Clone the repository (shallow clone for speed)
+	if err := runGit(tmpDir, "clone", "--depth", "1", "--branch", cfg.GitDefaultBranch, cloneURL, "repo"); err != nil {
+		return nil, fmt.Errorf("failed to clone repository: %w", err)
+	}
+
+	// Create and checkout the new branch
+	if err := runGit(repoDir, "checkout", "-b", branch); err != nil {
+		return nil, fmt.Errorf("failed to create branch: %w", err)
+	}
+
+	// Write each file
+	for _, f := range req.Files {
+		filePath := filepath.Join(repoDir, f.Path)
+
+		// Ensure the parent directory exists
+		if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+			return nil, fmt.Errorf("failed to create directory for %s: %w", f.Path, err)
+		}
+
+		if err := os.WriteFile(filePath, []byte(f.Content), 0644); err != nil {
+			return nil, fmt.Errorf("failed to write file %s: %w", f.Path, err)
+		}
+	}
+
+	// Stage all new/changed files
+	if err := runGit(repoDir, "add", "."); err != nil {
+		return nil, fmt.Errorf("failed to stage files: %w", err)
+	}
+
+	// Configure git user for the commit
+	if err := runGit(repoDir, "config", "user.email", "nachobot@redhat.com"); err != nil {
+		return nil, fmt.Errorf("failed to configure git email: %w", err)
+	}
+	if err := runGit(repoDir, "config", "user.name", "nachobot"); err != nil {
+		return nil, fmt.Errorf("failed to configure git name: %w", err)
+	}
+
+	// Commit
+	commitMsg := req.Title
+	if req.Description != nil && *req.Description != "" {
+		commitMsg = fmt.Sprintf("%s\n\n%s", req.Title, *req.Description)
+	}
+	if err := runGit(repoDir, "commit", "-m", commitMsg); err != nil {
+		return nil, fmt.Errorf("failed to commit: %w", err)
+	}
+
+	// Push the branch
+	if err := runGit(repoDir, "push", "origin", branch); err != nil {
+		return nil, fmt.Errorf("failed to push branch: %w", err)
+	}
+
+	// Create the pull request using the GitHub API via git
+	prURL, err := createGitHubPR(cfg, branch, req.Title, req.Description)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pull request: %w", err)
+	}
+
+	return &PullRequestResult{
+		PRUrl:  prURL,
+		Branch: branch,
+	}, nil
+}
+
+// ValidateFiles checks that the submitted files are valid
+func (s *GitService) ValidateFiles(files []generated.GitFile) error {
+	if len(files) == 0 {
+		return fmt.Errorf("at least one file is required")
+	}
+
+	for _, f := range files {
+		// Validate path is not empty
+		if strings.TrimSpace(f.Path) == "" {
+			return fmt.Errorf("file path cannot be empty")
+		}
+
+		// Prevent path traversal
+		cleanPath := filepath.Clean(f.Path)
+		if strings.HasPrefix(cleanPath, "..") || filepath.IsAbs(cleanPath) {
+			return fmt.Errorf("invalid file path: %s (path traversal not allowed)", f.Path)
+		}
+
+		// Content must not be empty
+		if strings.TrimSpace(f.Content) == "" {
+			return fmt.Errorf("file content cannot be empty for %s", f.Path)
+		}
+
+		// Validate YAML extension
+		ext := strings.ToLower(filepath.Ext(f.Path))
+		if ext != ".yaml" && ext != ".yml" && ext != ".json" {
+			return fmt.Errorf("unsupported file extension for %s: only .yaml, .yml, and .json are allowed", f.Path)
+		}
+	}
+
+	return nil
+}
+
+// generateBranchName creates a unique branch name from the PR title
+func generateBranchName(title string) (string, error) {
+	// Create a slug from the title
+	slug := slugify(title)
+	if len(slug) > 40 {
+		slug = slug[:40]
+	}
+
+	// Add a random suffix for uniqueness
+	suffix, err := randomHex(4)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("quickstart/%s-%s", slug, suffix), nil
+}
+
+// slugify converts a string to a URL-safe slug
+func slugify(s string) string {
+	s = strings.ToLower(s)
+	reg := regexp.MustCompile(`[^a-z0-9]+`)
+	s = reg.ReplaceAllString(s, "-")
+	s = strings.Trim(s, "-")
+	return s
+}
+
+// randomHex generates a random hex string of n bytes
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// buildAuthURL injects a token into an HTTPS git URL for authentication
+func buildAuthURL(repoURL, token string) (string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", fmt.Errorf("invalid repository URL: %w", err)
+	}
+
+	if u.Scheme != "https" {
+		return "", fmt.Errorf("only HTTPS repository URLs are supported")
+	}
+
+	u.User = url.UserPassword("x-access-token", token)
+	return u.String(), nil
+}
+
+// runGit executes a git command in the given directory
+func runGit(dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	// Mask credentials from logs
+	safeArgs := make([]string, len(args))
+	copy(safeArgs, args)
+	for i, arg := range safeArgs {
+		if strings.Contains(arg, "x-access-token") {
+			safeArgs[i] = "<REDACTED_URL>"
+		}
+	}
+	logrus.Debugf("git %s (in %s)", strings.Join(safeArgs, " "), dir)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		// Redact any tokens from the error output
+		sanitized := redactToken(string(output))
+		return fmt.Errorf("git %s failed: %s: %s", safeArgs[0], err, sanitized)
+	}
+	return nil
+}
+
+// redactToken removes any tokens from git output
+func redactToken(s string) string {
+	// Redact patterns like https://x-access-token:TOKEN@github.com
+	re := regexp.MustCompile(`(https?://)x-access-token:[^@]+@`)
+	return re.ReplaceAllString(s, "${1}***@")
+}
+
+// createGitHubPR creates a pull request using the GitHub REST API
+func createGitHubPR(cfg *config.QuickstartsConfig, branch, title string, description *string) (string, error) {
+	// Parse owner/repo from the repo URL
+	owner, repo, err := parseGitHubRepo(cfg.GitRepoURL)
+	if err != nil {
+		return "", err
+	}
+
+	body := ""
+	if description != nil {
+		body = *description
+	}
+
+	// Use curl to create the PR via GitHub API
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/%s/pulls", owner, repo)
+	jsonBody := fmt.Sprintf(
+		`{"title":%q,"head":%q,"base":%q,"body":%q}`,
+		title, branch, cfg.GitDefaultBranch, body,
+	)
+
+	cmd := exec.Command("curl", "-s", "-X", "POST",
+		"-H", "Accept: application/vnd.github+json",
+		"-H", fmt.Sprintf("Authorization: Bearer %s", cfg.GitAuthToken),
+		"-H", "Content-Type: application/json",
+		"-d", jsonBody,
+		apiURL,
+	)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("GitHub API request failed: %w", err)
+	}
+
+	// Parse the response to extract the PR URL
+	prURL, err := extractPRUrl(output)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse GitHub API response: %w: %s", err, redactToken(string(output)))
+	}
+
+	return prURL, nil
+}
+
+// parseGitHubRepo extracts owner and repo name from a GitHub URL
+func parseGitHubRepo(repoURL string) (string, string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid repository URL: %w", err)
+	}
+
+	// Path should be /owner/repo or /owner/repo.git
+	path := strings.Trim(u.Path, "/")
+	path = strings.TrimSuffix(path, ".git")
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("cannot parse owner/repo from URL: %s", repoURL)
+	}
+
+	return parts[0], parts[1], nil
+}
+
+// extractPRUrl parses the GitHub API JSON response to extract the html_url
+func extractPRUrl(response []byte) (string, error) {
+	// Simple JSON parsing without importing encoding/json to avoid
+	// a dependency on the exact response structure
+	// Look for "html_url": "..." in the response
+	s := string(response)
+
+	// Check for error response
+	if strings.Contains(s, `"message"`) && !strings.Contains(s, `"html_url"`) {
+		return "", fmt.Errorf("GitHub API error: %s", s)
+	}
+
+	// Find the html_url field (first occurrence is the PR URL)
+	marker := `"html_url":"`
+	idx := strings.Index(s, marker)
+	if idx == -1 {
+		return "", fmt.Errorf("html_url not found in response")
+	}
+
+	start := idx + len(marker)
+	end := strings.Index(s[start:], `"`)
+	if end == -1 {
+		return "", fmt.Errorf("malformed html_url in response")
+	}
+
+	return s[start : start+end], nil
+}

--- a/pkg/services/git_service_test.go
+++ b/pkg/services/git_service_test.go
@@ -1,0 +1,226 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/quickstarts/pkg/generated"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateFiles_EmptyFiles(t *testing.T) {
+	svc := NewGitService()
+	err := svc.ValidateFiles([]generated.GitFile{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one file is required")
+}
+
+func TestValidateFiles_EmptyPath(t *testing.T) {
+	svc := NewGitService()
+	err := svc.ValidateFiles([]generated.GitFile{
+		{Path: "", Content: "some content"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file path cannot be empty")
+}
+
+func TestValidateFiles_PathTraversal(t *testing.T) {
+	svc := NewGitService()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"dot-dot prefix", "../etc/passwd"},
+		{"nested dot-dot", "foo/../../etc/passwd"},
+		{"absolute path", "/etc/passwd"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateFiles([]generated.GitFile{
+				{Path: tt.path, Content: "content"},
+			})
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "path traversal not allowed")
+		})
+	}
+}
+
+func TestValidateFiles_EmptyContent(t *testing.T) {
+	svc := NewGitService()
+	err := svc.ValidateFiles([]generated.GitFile{
+		{Path: "quickstarts/test.yaml", Content: "  "},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "file content cannot be empty")
+}
+
+func TestValidateFiles_InvalidExtension(t *testing.T) {
+	svc := NewGitService()
+	err := svc.ValidateFiles([]generated.GitFile{
+		{Path: "quickstarts/test.txt", Content: "content"},
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported file extension")
+}
+
+func TestValidateFiles_ValidFiles(t *testing.T) {
+	svc := NewGitService()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"yaml extension", "quickstarts/my-quickstart.yaml"},
+		{"yml extension", "quickstarts/my-quickstart.yml"},
+		{"json extension", "quickstarts/my-quickstart.json"},
+		{"nested path", "data/quickstarts/getting-started/content.yaml"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateFiles([]generated.GitFile{
+				{Path: tt.path, Content: "name: test"},
+			})
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateFiles_MultipleFiles(t *testing.T) {
+	svc := NewGitService()
+	err := svc.ValidateFiles([]generated.GitFile{
+		{Path: "quickstarts/qs1.yaml", Content: "name: qs1"},
+		{Path: "quickstarts/qs2.yml", Content: "name: qs2"},
+	})
+	assert.NoError(t, err)
+}
+
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello World", "hello-world"},
+		{"Add New Quickstart: Getting Started", "add-new-quickstart-getting-started"},
+		{"Fix  Multiple   Spaces", "fix-multiple-spaces"},
+		{"special!@#chars$%^test", "special-chars-test"},
+		{"---leading-trailing---", "leading-trailing"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := slugify(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGenerateBranchName(t *testing.T) {
+	branch, err := generateBranchName("Add Getting Started Guide")
+	assert.NoError(t, err)
+	assert.Contains(t, branch, "quickstart/add-getting-started-guide-")
+	// Should have the quickstart/ prefix and a hex suffix
+	assert.Regexp(t, `^quickstart/[a-z0-9-]+-[0-9a-f]{8}$`, branch)
+}
+
+func TestGenerateBranchName_LongTitle(t *testing.T) {
+	longTitle := "This is a very long title that should be truncated to keep the branch name reasonable in length"
+	branch, err := generateBranchName(longTitle)
+	assert.NoError(t, err)
+	// Branch name prefix (quickstart/) + slug (max 40) + dash + hex (8) = max ~59 chars
+	assert.Less(t, len(branch), 65)
+}
+
+func TestBuildAuthURL(t *testing.T) {
+	result, err := buildAuthURL("https://github.com/org/repo.git", "my-token")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://x-access-token:my-token@github.com/org/repo.git", result)
+}
+
+func TestBuildAuthURL_NonHTTPS(t *testing.T) {
+	_, err := buildAuthURL("http://github.com/org/repo.git", "my-token")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "only HTTPS")
+}
+
+func TestBuildAuthURL_SSHUrl(t *testing.T) {
+	// SSH URLs don't have a scheme recognized by url.Parse in the same way
+	_, err := buildAuthURL("git@github.com:org/repo.git", "my-token")
+	assert.Error(t, err)
+}
+
+func TestParseGitHubRepo(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		wantOwner string
+		wantRepo  string
+		wantErr   bool
+	}{
+		{
+			name:      "standard HTTPS URL",
+			url:       "https://github.com/RedHatInsights/quickstarts.git",
+			wantOwner: "RedHatInsights",
+			wantRepo:  "quickstarts",
+		},
+		{
+			name:      "URL without .git",
+			url:       "https://github.com/RedHatInsights/quickstarts",
+			wantOwner: "RedHatInsights",
+			wantRepo:  "quickstarts",
+		},
+		{
+			name:    "invalid URL - too few parts",
+			url:     "https://github.com/RedHatInsights",
+			wantErr: true,
+		},
+		{
+			name:    "invalid URL - too many parts",
+			url:     "https://github.com/a/b/c",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			owner, repo, err := parseGitHubRepo(tt.url)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantOwner, owner)
+				assert.Equal(t, tt.wantRepo, repo)
+			}
+		})
+	}
+}
+
+func TestRedactToken(t *testing.T) {
+	input := "fatal: Authentication failed for 'https://x-access-token:ghp_secret123@github.com/org/repo.git'"
+	result := redactToken(input)
+	assert.NotContains(t, result, "ghp_secret123")
+	assert.Contains(t, result, "***@github.com")
+}
+
+func TestExtractPRUrl(t *testing.T) {
+	// Simplified GitHub API response
+	response := `{"url":"https://api.github.com/repos/org/repo/pulls/42","html_url":"https://github.com/org/repo/pull/42","number":42}`
+	prURL, err := extractPRUrl([]byte(response))
+	assert.NoError(t, err)
+	assert.Equal(t, "https://github.com/org/repo/pull/42", prURL)
+}
+
+func TestExtractPRUrl_ErrorResponse(t *testing.T) {
+	response := `{"message":"Validation Failed","errors":[{"resource":"PullRequest"}]}`
+	_, err := extractPRUrl([]byte(response))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "GitHub API error")
+}
+
+func TestExtractPRUrl_MissingField(t *testing.T) {
+	response := `{"id":123,"number":42}`
+	_, err := extractPRUrl([]byte(response))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "html_url not found")
+}

--- a/pkg/services/git_service_test.go
+++ b/pkg/services/git_service_test.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"encoding/json"
+	"os"
 	"testing"
 
 	"github.com/RedHatInsights/quickstarts/pkg/generated"
@@ -132,22 +134,21 @@ func TestGenerateBranchName_LongTitle(t *testing.T) {
 	assert.Less(t, len(branch), 65)
 }
 
-func TestBuildAuthURL(t *testing.T) {
-	result, err := buildAuthURL("https://github.com/org/repo.git", "my-token")
+func TestCreateAskpassScript(t *testing.T) {
+	tmpDir := t.TempDir()
+	script, err := createAskpassScript("test-token", tmpDir)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://x-access-token:my-token@github.com/org/repo.git", result)
-}
+	defer os.Remove(script)
 
-func TestBuildAuthURL_NonHTTPS(t *testing.T) {
-	_, err := buildAuthURL("http://github.com/org/repo.git", "my-token")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "only HTTPS")
-}
+	// Verify the script exists and is executable
+	info, err := os.Stat(script)
+	assert.NoError(t, err)
+	assert.True(t, info.Mode()&0100 != 0, "script should be executable")
 
-func TestBuildAuthURL_SSHUrl(t *testing.T) {
-	// SSH URLs don't have a scheme recognized by url.Parse in the same way
-	_, err := buildAuthURL("git@github.com:org/repo.git", "my-token")
-	assert.Error(t, err)
+	// Verify the script content echoes the token
+	content, err := os.ReadFile(script)
+	assert.NoError(t, err)
+	assert.Contains(t, string(content), "test-token")
 }
 
 func TestParseGitHubRepo(t *testing.T) {
@@ -203,24 +204,28 @@ func TestRedactToken(t *testing.T) {
 	assert.Contains(t, result, "***@github.com")
 }
 
-func TestExtractPRUrl(t *testing.T) {
-	// Simplified GitHub API response
-	response := `{"url":"https://api.github.com/repos/org/repo/pulls/42","html_url":"https://github.com/org/repo/pull/42","number":42}`
-	prURL, err := extractPRUrl([]byte(response))
+func TestGhPullRequestResponseParsing(t *testing.T) {
+	// Test that the JSON struct correctly parses GitHub API responses
+	response := `{"html_url":"https://github.com/org/repo/pull/42","number":42}`
+	var prResp ghPullRequestResponse
+	err := json.Unmarshal([]byte(response), &prResp)
 	assert.NoError(t, err)
-	assert.Equal(t, "https://github.com/org/repo/pull/42", prURL)
+	assert.Equal(t, "https://github.com/org/repo/pull/42", prResp.HTMLURL)
 }
 
-func TestExtractPRUrl_ErrorResponse(t *testing.T) {
-	response := `{"message":"Validation Failed","errors":[{"resource":"PullRequest"}]}`
-	_, err := extractPRUrl([]byte(response))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "GitHub API error")
+func TestGhPullRequestResponseParsing_ErrorResponse(t *testing.T) {
+	response := `{"message":"Validation Failed"}`
+	var prResp ghPullRequestResponse
+	err := json.Unmarshal([]byte(response), &prResp)
+	assert.NoError(t, err)
+	assert.Equal(t, "Validation Failed", prResp.Message)
+	assert.Empty(t, prResp.HTMLURL)
 }
 
-func TestExtractPRUrl_MissingField(t *testing.T) {
-	response := `{"id":123,"number":42}`
-	_, err := extractPRUrl([]byte(response))
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "html_url not found")
+func TestGhPullRequestResponseParsing_EmptyURL(t *testing.T) {
+	response := `{"html_url":"","number":42}`
+	var prResp ghPullRequestResponse
+	err := json.Unmarshal([]byte(response), &prResp)
+	assert.NoError(t, err)
+	assert.Empty(t, prResp.HTMLURL)
 }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -206,14 +206,6 @@
         },
         "type": "object"
       },
-      "InternalServerError": {
-        "properties": {
-          "msg": {
-            "type": "string"
-          }
-        },
-        "type": "object"
-      },
       "FavoriteQuickstart": {
         "properties": {
           "accountId": {
@@ -336,6 +328,14 @@
           },
           "updatedAt": {
             "format": "date-time",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "InternalServerError": {
+        "properties": {
+          "msg": {
             "type": "string"
           }
         },

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -233,6 +233,61 @@
         },
         "type": "object"
       },
+      "GitFile": {
+        "properties": {
+          "content": {
+            "description": "File content (YAML)",
+            "type": "string"
+          },
+          "path": {
+            "description": "Relative file path within the repository",
+            "type": "string"
+          }
+        },
+        "required": [
+          "path",
+          "content"
+        ],
+        "type": "object"
+      },
+      "GitPullRequestRequest": {
+        "properties": {
+          "description": {
+            "description": "Optional pull request description",
+            "type": "string"
+          },
+          "files": {
+            "description": "List of files to include in the pull request",
+            "items": {
+              "$ref": "#/components/schemas/GitFile"
+            },
+            "minItems": 1,
+            "type": "array"
+          },
+          "title": {
+            "description": "Pull request title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "files",
+          "title"
+        ],
+        "type": "object"
+      },
+      "GitPullRequestResponse": {
+        "properties": {
+          "branch": {
+            "description": "Name of the branch created",
+            "type": "string"
+          },
+          "prUrl": {
+            "description": "URL of the created pull request",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "HelpTopic": {
         "properties": {
           "content": {
@@ -491,6 +546,59 @@
           }
         },
         "summary": "Add a favorite"
+      }
+    },
+    "/git/pull-request": {
+      "post": {
+        "description": "Accepts quickstart YAML files, validates them, clones the target repository, creates a branch, commits the files, pushes, and opens a pull request. Returns the PR URL.\n",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GitPullRequestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GitPullRequestResponse"
+                    }
+                  },
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Pull request created successfully"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                }
+              }
+            },
+            "description": "Bad request (validation error)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadRequest"
+                }
+              }
+            },
+            "description": "Internal server error (git operation failed)"
+          }
+        },
+        "summary": "Create a pull request with quickstart files"
       }
     },
     "/helptopics": {

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -206,6 +206,14 @@
         },
         "type": "object"
       },
+      "InternalServerError": {
+        "properties": {
+          "msg": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
       "FavoriteQuickstart": {
         "properties": {
           "accountId": {
@@ -591,7 +599,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/BadRequest"
+                  "$ref": "#/components/schemas/InternalServerError"
                 }
               }
             },

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -134,6 +134,45 @@ components:
         value:
           type: string
       type: object
+    GitFile:
+      properties:
+        path:
+          type: string
+          description: Relative file path within the repository
+        content:
+          type: string
+          description: File content (YAML)
+      required:
+        - path
+        - content
+      type: object
+    GitPullRequestRequest:
+      properties:
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/GitFile'
+          minItems: 1
+          description: List of files to include in the pull request
+        title:
+          type: string
+          description: Pull request title
+        description:
+          type: string
+          description: Optional pull request description
+      required:
+        - files
+        - title
+      type: object
+    GitPullRequestResponse:
+      properties:
+        prUrl:
+          type: string
+          description: URL of the created pull request
+        branch:
+          type: string
+          description: Name of the branch created
+      type: object
   parameters:
       ProductFamilies:
         name: product-families
@@ -533,4 +572,39 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/NotFound'
+  /git/pull-request:
+    post:
+      summary: Create a pull request with quickstart files
+      description: >
+        Accepts quickstart YAML files, validates them, clones the target
+        repository, creates a branch, commits the files, pushes, and
+        opens a pull request. Returns the PR URL.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GitPullRequestRequest'
+      responses:
+        '201':
+          description: Pull request created successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/GitPullRequestResponse'
+        '400':
+          description: Bad request (validation error)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
+        '500':
+          description: Internal server error (git operation failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BadRequest'
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5,6 +5,11 @@ components:
         msg:
           type: string
       type: object
+    InternalServerError:
+      properties:
+        msg:
+          type: string
+      type: object
     NotFound:
       properties:
         msg:
@@ -606,5 +611,5 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BadRequest'
+                $ref: '#/components/schemas/InternalServerError'
 


### PR DESCRIPTION
## Summary

- Adds `POST /git/pull-request` endpoint to the Quickstarts API that accepts quickstart YAML files, validates them, clones the target repository, creates a branch, commits the files, pushes, and opens a GitHub pull request
- Implements file validation (path traversal prevention, extension whitelist, content checks), authenticated git operations, branch name generation, and credential redaction in logs
- Adds configuration via `GIT_REPO_URL`, `GIT_AUTH_TOKEN`, `GIT_DEFAULT_BRANCH`, `GIT_TEMP_DIR` environment variables

**RHCLOUD-39697** — prerequisite: RHCLOUD-39698 (git-core in Docker image)

## Test plan

- [x] Unit tests for file validation (empty files, path traversal, invalid extensions, empty content)
- [x] Unit tests for URL parsing, slug generation, branch naming, token redaction
- [x] Unit tests for handler error paths (invalid JSON, missing title, missing config)
- [x] OpenAPI spec validates successfully
- [x] All existing tests continue to pass
- [ ] Integration test with real GIT_REPO_URL and GIT_AUTH_TOKEN (requires deployment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a git proxy endpoint that creates GitHub pull requests with validated quickstart files using configurable repository settings.

New Features:
- Expose a POST /git/pull-request API that accepts quickstart files and opens a pull request in a configured GitHub repository.
- Introduce Git service logic to clone the target repo, create a branch, commit provided files, push, and create a GitHub pull request.
- Add configuration for git proxy behavior via GIT_REPO_URL, GIT_AUTH_TOKEN, GIT_DEFAULT_BRANCH, and GIT_TEMP_DIR environment variables.

Enhancements:
- Extend the OpenAPI specification and generated models to describe git pull request request/response payloads.
- Wire a new GitService into the server adapter to support the git pull request route.

Tests:
- Add unit tests for git file validation, branch naming, URL parsing, token redaction, and GitHub response parsing.
- Add HTTP handler tests covering request validation and error paths for the /git/pull-request endpoint.