### PR TITLE
feat(git-service): update clowdapp config

### DIFF
--- a/deploy/clowdapp.yml
+++ b/deploy/clowdapp.yml
@@ -54,6 +54,11 @@ objects:
         env:
         - name: CLOWDER_ENABLED
           value: ${CLOWDER_ENABLED}
+        - name: PSK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: quickstarts-git-service
+              key: PSK_TOKEN
         resources:
           limits:
             cpu: ${CPU_LIMIT}
@@ -67,6 +72,69 @@ objects:
         volumeMounts:
         - mountPath: /tmp
           name: tmpdir
+    - name: git-service
+      minReplicas: ${{GIT_SERVICE_MIN_REPLICAS}}
+      webServices:
+        private:
+          enabled: true
+      podSpec:
+        image: ${GIT_SERVICE_IMAGE}:${GIT_SERVICE_IMAGE_TAG}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /test
+            port: 8001
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /test
+            port: 8001
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+        env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: quickstarts-git-service
+              key: GITHUB_TOKEN
+        - name: GITHUB_REPO_URL
+          value: ${GITHUB_REPO_URL}
+        - name: GITHUB_BASE_BRANCH
+          value: ${GITHUB_BASE_BRANCH}
+        - name: PR_REVIEWERS_TEAM
+          value: ${PR_REVIEWERS_TEAM}
+        - name: QUICKSTARTS_REPO_PATH
+          value: /var/quickstarts-repo
+        - name: QUICKSTARTS_DIR_PATH
+          value: ${QUICKSTARTS_DIR_PATH}
+        - name: PORT
+          value: "8001"
+        - name: CLOWDER_ENABLED
+          value: ${CLOWDER_ENABLED}
+        - name: PSK_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: quickstarts-git-service
+              key: PSK_TOKEN
+        resources:
+          limits:
+            cpu: 200m
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumes:
+        - emptyDir: {}
+          name: quickstarts-repo
+        volumeMounts:
+        - mountPath: /var/quickstarts-repo
+          name: quickstarts-repo
 
 parameters:
 - name: LOG_LEVEL
@@ -92,3 +160,24 @@ parameters:
   name: ENV_NAME
   value: "quickstarts"
   required: true
+- name: GIT_SERVICE_MIN_REPLICAS
+  value: '1'
+- description: Git service image name
+  name: GIT_SERVICE_IMAGE
+  value: quay.io/redhat-services-prod/hcc-platex-services/quickstarts-git-service
+- description: Git service image tag
+  name: GIT_SERVICE_IMAGE_TAG
+  value: 'latest'
+  required: true
+- description: GitHub repository URL for git-service
+  name: GITHUB_REPO_URL
+  value: https://github.com/RedHatInsights/quickstarts
+- description: Base branch for PRs
+  name: GITHUB_BASE_BRANCH
+  value: main
+- description: GitHub team slug for PR reviewers
+  name: PR_REVIEWERS_TEAM
+  value: ""
+- description: Directory path for quickstart files within the repo
+  name: QUICKSTARTS_DIR_PATH
+  value: /docs/quickstarts/


### PR DESCRIPTION
### Description
<!-- Summary of proposed changes: what and why. -->

[RHCLOUD-48693](https://redhat.atlassian.net/browse/RHCLOUD-48693)

Adds the Dockerfile and ClowdApp deployment config for the git-service. Deploys the git-service as a separate Clowder deployment (not a sidecar) with its own private endpoint, container image, and resource limits. Please merge this after merging these 3 PR 

---

### How to test locally
<!-- How can a reviewer exercise this? Special setup, env vars, seed data? -->
<!-- Bug fixes: how to reproduce the original bug and confirm the fix. -->

```bash
# Build the git-service container image
podman build -f Dockerfile.git-service -t quickstarts-git-service .

# Run the container
podman run -p 8001:8001 \
  -e GITHUB_TOKEN=<token> \
  -e GITHUB_REPO_URL=https://github.com/owner/repo \
  quickstarts-git-service

# Health check
curl http://localhost:8001/test
```

---

### Anything reviewers should know?
<!-- Trade-offs, performance considerations, pre/post merge actions required. -->
The Konflux component still needs to be registered after this PR merges.
---

### Checklist
- [ ] Tests: new/updated tests cover the change
- [ ] API: spec updated if endpoints changed (or N/A)
- [ ] Migrations: backwards compatible if schema changed (or N/A)
- [ ] Dependencies: no known impact to dependent services
- [ ] Security: reviewed against [secure coding checklist](https://github.com/RedHatInsights/secure-coding-checklist) (or N/A)

### AI disclosure
<!-- If AI tools contributed, note them. E.g.: Assisted by: Claude Code -->
Assisted by: Claude Code


[RHCLOUD-48693]: https://redhat.atlassian.net/browse/RHCLOUD-48693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ